### PR TITLE
Appending path of userdef_environments to sys.path

### DIFF
--- a/lib/doconce/doconce.py
+++ b/lib/doconce/doconce.py
@@ -2063,12 +2063,17 @@ def typeset_userdef_envirs(filestr, format):
         return filestr
     userfile = 'userdef_environments.py'
     if os.path.isfile(userfile):
+        sys_path_original = list(sys.path)
+        sys.path.append(os.path.dirname(os.path.realpath(userfile)))
         try:
             import userdef_environments as ue
         except Exception as e:
-            print '*** error in %s:' % userfile
+            print "*** error on import userdef_environments"
+            print "*** when trying to import %s " % os.path.abspath(userfile)
+            print "*** error:"
             print e
             _abort()
+        sys.path = list(sys_path_original)
     else:
         print '*** error: found user-defined environments'
         print '   ', ', '.join(list(set(userdef_envirs)))


### PR DESCRIPTION
For some reason the current path is no longer present in sys.path when doconce.py tries to import userdef_environments.py. This patch includes the current path temporarily during the import. This issue may however be fixed by figuring out why the current path (also known as '') is removed from sys.path in the first place.

Note that this issue occured after installing doconce and all dependencies in a virtual environment. However, when running python in terminal, sys.path includes the current path ('') by default. This can be checked by running:

```
import sys
print sys.path
```

In other words, something seems to modify sys.path by mistake.