### PR TITLE
Fixed copyright symbol for HTML

### DIFF
--- a/doc/src/trouble/trouble.do.txt
+++ b/doc/src/trouble/trouble.do.txt
@@ -1085,7 +1085,7 @@ shows the formula correctly. The next step is to compile to HTML and
 check if MathJax in pure HTML renders the formula correctly. If so,
 the formula is correctly typeset, and the problem is related to Sphinx.
 
-There are basically to remedies: either drop Sphinx and go for HTML, or
+There are basically two remedies: either drop Sphinx and go for HTML, or
 try to rewrite the formula and try until the Sphinx-generated
 HTML code manages to render it.
 

--- a/lib/doconce/common.py
+++ b/lib/doconce/common.py
@@ -169,17 +169,21 @@ def is_file_or_url(filename, msg='checking existence of', debug=True):
 
 
 def has_copyright(filestr):
+    copyright_ = False
     # We use the copyright field for citing doconce
     if option('cite_doconce'):
-        return True
+        copyright_ = True
     # Check each author for explicit copyright
     authors = re.findall(r'^AUTHOR:(.+)', filestr, flags=re.MULTILINE)
-    copyright_ = False
+
+    symbol = False  # We do not need a (c)-symbol if we're only citing doconce
     for author in authors:
         if '{copyright' in author:
             copyright_ = True
+            symbol = True
             break
-    return copyright_
+    print copyright_, symbol
+    return copyright_, symbol
 
 def get_copyfile_info(filestr=None, copyright_filename=None, format=None):
     """Return copyright tuple in .filename.copyright."""

--- a/lib/doconce/common.py
+++ b/lib/doconce/common.py
@@ -182,7 +182,6 @@ def has_copyright(filestr):
             copyright_ = True
             symbol = True
             break
-    print copyright_, symbol
     return copyright_, symbol
 
 def get_copyfile_info(filestr=None, copyright_filename=None, format=None):

--- a/lib/doconce/html.py
+++ b/lib/doconce/html.py
@@ -2972,13 +2972,14 @@ Automatically generated HTML file from DocOnce source
 -->
 """
     from common import has_copyright
-    if has_copyright(filestr):
+    copyright_, symbol = has_copyright(filestr)
+    if copyright_:
         OUTRO['html'] += """
 
 <center style="font-size:80%">
-<!-- copyright --> &copy; Copyright COPYRIGHT_HOLDERS
+<!-- copyright --> {} Copyright COPYRIGHT_HOLDERS
 </center>
-"""
+""".format("&copy;" if symbol else "")
     OUTRO['html'] += """
 
 </body>

--- a/lib/doconce/latex.py
+++ b/lib/doconce/latex.py
@@ -1870,8 +1870,8 @@ def latex_ref_and_label(section_label2title, format, filestr):
     #filestr = re.sub(r'([A-Za-z])\s*&\s*([A-Za-z])', r'\g<1>{\&}\g<2>', filestr)
 
     # handle non-English characters:
-    chars = {'\E6': r'{\ae}', '\F8': r'{\o}', '\E5': r'{\aa}',
-             '\C6': r'{\AE}', '\D8': r'{\O}', '\C5': r'{\AA}',
+    chars = {'æ': r'{\ae}', 'ø': r'{\o}', 'å': r'{\aa}',
+             'Æ': r'{\AE}', 'Ø': r'{\O}', 'Å': r'{\AA}',
              }
     # Not implemented
     #for c in chars:

--- a/lib/doconce/latex.py
+++ b/lib/doconce/latex.py
@@ -1870,8 +1870,8 @@ def latex_ref_and_label(section_label2title, format, filestr):
     #filestr = re.sub(r'([A-Za-z])\s*&\s*([A-Za-z])', r'\g<1>{\&}\g<2>', filestr)
 
     # handle non-English characters:
-    chars = {'æ': r'{\ae}', 'ø': r'{\o}', 'å': r'{\aa}',
-             'Æ': r'{\AE}', 'Ø': r'{\O}', 'Å': r'{\AA}',
+    chars = {'\E6': r'{\ae}', '\F8': r'{\o}', '\E5': r'{\aa}',
+             '\C6': r'{\AE}', '\D8': r'{\O}', '\C5': r'{\AA}',
              }
     # Not implemented
     #for c in chars:
@@ -3358,7 +3358,7 @@ open=right,              %% start new chapters on odd-numbered pages
 """
 
     from common import has_copyright
-    copyright_ = has_copyright(filestr)
+    copyright_, symbol = has_copyright(filestr)
     fancy_header = option('latex_fancy_header')
     if fancy_header or copyright_:
         INTRO['latex'] += r"""

--- a/lib/doconce/misc.py
+++ b/lib/doconce/misc.py
@@ -3456,7 +3456,7 @@ def doconce_split_html(header, parts, footer, basename, filename, slides=False):
             # Remove the copyright from the footer
             for i in range(len(footer)):
                 if '<!-- copyright -->' in footer[i]:
-                    footer[i] = re.sub(r'<!-- copyright --> &copy;.+', '<!-- copyright only on the titlepage -->', footer[i])
+                    footer[i] = re.sub(r'<!-- copyright --> .+', '<!-- copyright only on the titlepage -->', footer[i])
 
         # Navigation in the bottom of the page
         lines.append('<p>\n')
@@ -3558,7 +3558,7 @@ def generate_html5_slides(header, parts, footer, basename, filename,
         copy_datafiles(eval(slide_tp + '_files'))  # copy to subdir if needed
 
     # Copyright in the footer?
-    pattern = r'<center style="font-size:80%">\n<!-- copyright --> &copy; (.+)\n</center>'
+    pattern = r'<center style="font-size:80%">\n<!-- copyright --> (.+)\n</center>'
     m = re.search(pattern, ''.join(footer))
     if m:
         copyright_ = m.group().strip()


### PR DESCRIPTION
Fixed copyright symbol being displayed when citing DocOnce without there being any other copyright information, but only for HTML (LaTeX code was only edited for compatibilty).