### PR TITLE
Fix the python import statemant for BeautifulSoup.

### DIFF
--- a/lib/doconce/doconce.py
+++ b/lib/doconce/doconce.py
@@ -4350,9 +4350,9 @@ def doconce2format(filestr, format):
             filestr = '<!DOCTYPE HTML>\n' + filestr
         if option('xhtml'):
             try:
-                from bs4 import BeautifulSoap as BS
+                from bs4 import BeautifulSoup as BS
             except ImportError:
-                print '*** error: for --xhtml the bs4 BeautifulSoap package must be installed'
+                print '*** error: for --xhtml the bs4 BeautifulSoup package must be installed'
                 print '    pip install beautifulsoup4'
                 _abort()
             soup = BS(filestr)


### PR DESCRIPTION
Fix the python import statement for BeautifulSoup for the xhtml option.
This works fine but this produce the following warning message:

> UserWarning: No parser was explicitly specified, so I'm using the best available HTML parser for this > system ("lxml"). This usually isn't a problem, but if you run this code on another system, or in a
> different virtual environment, it may use a different parser and behave differently.
>
> To get rid of this warning, change this:
>
> BeautifulSoup([your markup])
>
> to this:
>
> BeautifulSoup([your markup], "lxml")

To fix this one possible solution were to change the line `soup = BS(filestr)` with `soup = BS(filestr, "lxml")` or to pass the parser via an command line option.

