### PR TITLE
Added notes about eqrefs and non-breakable space before ref

### DIFF
--- a/doc/src/manual/manual.do.txt
+++ b/doc/src/manual/manual.do.txt
@@ -1882,6 +1882,21 @@ Additional references to Sections ref{mathtext} and ref{newcommands} are
 nice to demonstrate, as well as a reference to equations,
 say (ref{myeq1})-(ref{myeq2}).
 
+!bwarning References to equations have to be enclosed into parentheses.
+
+The correct syntax for eqrefs is the following (remove spaces between parentheses and `ref{...}`):
+## It seems that it is impossible to get `(ref{eq:ref})` rendered properly
+## So we do this 'remove spaces' trick
+!bc do
+...see equation ( ref{eq:yourref} )...
+!ec
+
+If you forget parentheses, you'll get error message: `error: references to labels
+not defined in this document`.
+!ewarning
+
+Note also that you *should not* prepend `ref{...}` with non-breakable space: it will be
+added in LaTeX mode automatically. 
 
 Hyperlinks to files or web addresses are handled as explained
 in Section ref{inline:tagging}.


### PR DESCRIPTION
It is very surprising that one have to write `(ref{eq:ref})` in order to make reference to an equation, so I believe it is better to discuss it in the docs at least.

Also, I found no way to express the correct syntax explicitly, because all these eqrefs (even in backticks and `!bc do` environment) are rendered by doconce. So I added spaces between parenthesis and eqref and asked the reader to remove it on their side. (Are there any better way to do it?)