### PR TITLE
Enumerated envs

### DIFF
--- a/doc/src/manual/manual.do.txt
+++ b/doc/src/manual/manual.do.txt
@@ -4012,6 +4012,13 @@ To summarize, the *example* environment together with the `refex` Mako
 function allows you to work with native LaTeX example environments, while
 there is a neat alternative solution for all other formats.
 
+!bnotice Enumerated environments
+It is also possible to make enumerated environments such that their `ref`s use numbers
+instead of section headings in HTML format (just like Figures do). This mimics LaTeX
+behaviour on theorem-style environments. See the example in "DocOnce repository":
+"https://github.com/hplgit/doconce/blob/master/doc/src/userdef_envirs/enumerated_envs".
+!enotice
+
 You may take a look at a complete "`userdef_environments.py`":
 "https://github.com/hplgit/doconce/blob/master/doc/src/manual/userdef_environments.py"
 file to see this example environment and another *highligh* environment

--- a/doc/src/userdef_envirs/enumerated_envs/userdef_environments.py
+++ b/doc/src/userdef_envirs/enumerated_envs/userdef_environments.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+#
+# (c) Ilya V. Schurov <ilya@schurov.com>, 2016
+# Based on example_and_colorbox example by Hans Petter Langtangen
+# Licensed under BSD 3-Clause License (like the rest of DocOnce, see LICENSE)
+#
+# -*- coding: utf-8 -*-
+from mako.template import Template
+import re
+
+envir2format = {
+    'intro': {
+        'latex': u"""
+\\usepackage{amsthm}
+\\theoremstyle{definition}
+\\newtheorem{remark}{Remark}
+\\newtheorem{example}{Example}
+\\newtheorem{definition}{Definition}
+""",}
+}
+envirs = ['remark', 'example', 'definition']
+for env in envirs:
+    envir2format.update({
+        env: {
+            'latex': lambda text, titleline, counter, format, env=env: latex_env(env, text, titleline, counter, format),
+            'do': lambda text, titleline, counter, format, env=env: do_env(env, text, titleline, counter, format),
+            'html': lambda text, titleline, counter, format, env=env: html_env(env, text, titleline, counter, format),
+        },
+    })
+
+def get_label(titleline):
+    """
+    Extract label from title line in begin environment.
+    Return label and title (without label).
+    """
+    label = ''
+    if 'label=' in titleline:
+        pattern = r'label=([^\s]+)'
+        m = re.search(pattern, titleline)
+        if m:
+            label = m.group(1)
+            titleline = re.sub(pattern, '', titleline).strip()
+    return label, titleline
+
+def latex_env(env, text, titleline, counter, format):
+    """LaTeX typesetting of theorem-style environment."""
+    label, titleline = get_label(titleline)
+    titleline = titleline.strip()
+    template = ur"""
+\begin{${env}}
+% if label:
+label{${label}}
+% endif
+% if titleline:
+\noindent\emph{${titleline}.
+%endif
+${text}
+\end{${env}}
+"""
+    return Template(template).render(**vars())
+
+def do_env(env, text, titleline, counter, format):
+    """General typesetting of theorem-style environment via a section."""
+    label, titleline = get_label(titleline)
+    titleline = titleline.strip()
+    if titleline:
+        titleline = ": "+titleline
+    template = ur"""
+===== ${env.capitalize()} ${counter} ${titleline} =====
+% if label:
+label{${label}}
+% endif
+${text}
+
+"""
+    return Template(template).render(**vars())
+
+def html_env(env, text, titleline, counter, format):
+    """HTML typesetting of theorem-style environment."""
+    label, titleline = get_label(titleline)
+    titleline = titleline.strip()
+    template = ur"""
+% if label:
+<!-- custom environment: label=${label}, number=${counter} -->
+% endif
+<p class='env-${env}'><strong>${env.capitalize()} ${counter}${titleline}.</strong> 
+${text}
+</p>
+"""
+    return Template(template).render(**vars())

--- a/lib/doconce/html.py
+++ b/lib/doconce/html.py
@@ -1996,6 +1996,7 @@ def html_ref_and_label(section_label2title, format, filestr):
     # We look for all such environments, extract their numbers 
     # from special comment tag and record it to label2no along with Figure's
     # numbers
+    #
     # We allow 'no-number numbers' like 'Theorem A', so use number=([^\s]+?) pattern
     # instead of number=(\d+?)
 

--- a/lib/doconce/html.py
+++ b/lib/doconce/html.py
@@ -1985,11 +1985,22 @@ def html_ref_and_label(section_label2title, format, filestr):
     # Number all figures, find all figure labels and replace their
     # references by the figure numbers
     # (note: figures are already handled!)
+    #
     caption_start = '<p class="caption">'
     caption_pattern = r'%s(.+?)</p>' % caption_start
     #label_pattern = r'%s.+?<a name="(.+?)">' % caption_start
     label_pattern = r'%s.+? <!-- caption label: (.+?) -->' % caption_start
     # Should have <h\d id=""> type of labels too
+
+    # References to custom numbered environments are also handled here
+    # We look for all such environments, extract their numbers 
+    # from special comment tag and record it to label2no along with Figure's
+    # numbers
+    # We allow 'no-number numbers' like 'Theorem A', so use number=([^\s]+?) pattern
+    # instead of number=(\d+?)
+
+    custom_env_pattern = r'<!--\s*custom environment:\s*label=([^\s]+?),\s*number=([^\s]+?)\s*-->'
+
     lines = filestr.splitlines()
     label2no = {}
     fig_no = 0
@@ -2006,12 +2017,23 @@ def html_ref_and_label(section_label2title, format, filestr):
             m = re.search(label_pattern, lines[i])
             if m:
                 label2no[m.group(1)] = fig_no
+
+        # process custom environments
+        m = re.search(custom_env_pattern, lines[i])
+        if m:
+            label2no[m.group(1)] = m.group(2)
+
+            # replace the special comment with an anchor
+            lines[i] = re.sub(custom_env_pattern, 
+                    "<div id=\"%s\" />" % m.group(1), lines[i])
+
     filestr = '\n'.join(lines)
 
-    for label in label2no:
+    for label, no in label2no.iteritems():
         filestr = filestr.replace('ref{%s}' % label,
-                                  '<a href="#%s">%d</a>' %
-                                  (label, label2no[label]))
+                                  '<a href="#%s">%s</a>' % (label, str(no)))
+        # we allow 'non-number numbers' for custom environments like 'theorem A'
+        # so str(no)
 
     # replace all other references ref{myname} by <a href="#myname">myname</a>:
     for label in running_text_labels:


### PR DESCRIPTION
This PR proposes new feature: number-only references to enumerated user-defined environments in HTML format. This allows to get references like `See Theorem <a href="#thm:existence">3</a>…` just like it is done in LaTeX. An example that mimics AMSLaTeX theorem-style definitions is presented.