### PR TITLE
Change escapeinside from || to (@* *@) due to problems with pipes in code

### DIFF
--- a/lib/doconce/latex.py
+++ b/lib/doconce/latex.py
@@ -260,7 +260,7 @@ def latex_code_lstlisting(latex_code_style):
   showtabs=false,
   keepspaces=true,
   columns=fullflexible,      % tighter character kerning, like verb
-  escapeinside={||},         % for |\pause| in slides and math in code blocks
+  escapeinside={(*@}{@*)},   % (*@ \pause @*) in slides and math in code blocks
   extendedchars=\true,       % allows non-ascii chars, does not work with utf-8
 }
 


### PR DESCRIPTION
Code or text files containing pipes '|' are garbled when formatted by lstlistings. This is caused by the escapeinside setting in lstset. Because pipes are so common in code and data files, I would suggest using more obscure escape characters or sequences.

This pull request changes the escape sequence to (@* and *@) such that this example would work:

    !bc
    this is code with (@* escaped text and math *@) inlined
    !ec