### PR TITLE
Fixed issue with installing lxml via pip due to missing dependencies in Ubuntu 16.04

### DIFF
--- a/doc/src/manual/debpkg_doconce.txt
+++ b/doc/src/manual/debpkg_doconce.txt
@@ -40,6 +40,9 @@ pip install -e git+https://github.com/hplgit/preprocess#egg=preprocess
 
 # Publish for handling bibliography
 pip install python-Levenshtein
+libxml2-dev
+libxslt1-dev
+zlib1g-dev
 pip install lxml
 pip install -e hg+https://bitbucket.org/logg/publish#egg=publish
 

--- a/doc/src/manual/install_doconce.py
+++ b/doc/src/manual/install_doconce.py
@@ -75,6 +75,9 @@ system('sudo pip install -e git+https://github.com/hplgit/preprocess#egg=preproc
 
 # Publish for handling bibliography
 system('sudo pip install python-Levenshtein')
+system('sudo apt-get -y install libxml2-dev')
+system('sudo apt-get -y install libxslt1-dev')
+system('sudo apt-get -y install zlib1g-dev')
 system('sudo pip install lxml')
 system('sudo pip install -e hg+https://bitbucket.org/logg/publish#egg=publish')
 

--- a/doc/src/manual/install_doconce.sh
+++ b/doc/src/manual/install_doconce.sh
@@ -67,6 +67,9 @@ pip_install -e git+https://github.com/hplgit/preprocess#egg=preprocess
 
 # Publish for handling bibliography
 pip_install python-Levenshtein
+apt_install libxml2-dev
+apt_install libxslt1-dev
+apt_install zlib1g-dev
 pip_install lxml
 pip_install -e hg+https://bitbucket.org/logg/publish#egg=publish
 


### PR DESCRIPTION
Had problems running `install_doconce.py` on a fresh install of Ubuntu 16.04 due to missing dependencies for `lxml`. (I guess they used to be included with previous versions of Ubuntu.)
Found a post on [Stack Overflow](http://stackoverflow.com/questions/5178416/pip-install-lxml-error) indicating that `libxml2-dev`, `libxslt1-dev`, `zlib1g-dev` are required by `lxml`, and after installing these via apt, the installation went smoothly. Thus I suggest including these packages in the install scripts.
