### PR TITLE
Removed conversion from Unicode to ASCII which caused UnicodeEncodeEr…

### DIFF
--- a/lib/doconce/doconce.py
+++ b/lib/doconce/doconce.py
@@ -30,7 +30,6 @@ def errwarn(msg, newline=True):
         print msg
     else:
         print msg,
-    msg = str(msg)
     logfilename = dofile_basename + '.dolog'
     mode = 'a' if os.path.isfile(logfilename) else 'w'
     if encoding:


### PR DESCRIPTION
I had an issue where DocOnce would crash when 'ø' appeared in a Unicode string sent to errwarn. This Unicode string can't be converted to ASCII since 'ø' (`u'\xf8'`) is not contained in the ASCII table causing a UnicodeEncodeError. Simply removing this conversion seems to work fine.