### PR TITLE
Fixed offsetting of heading anchors in Bootstrap

### DIFF
--- a/lib/doconce/html.py
+++ b/lib/doconce/html.py
@@ -2841,13 +2841,13 @@ pre { color: inherit; background-color: transparent; }
    overflow-x: hidden;
 }
 
-/* Position anchors of headings a bit higher so jumping to headlines
-behaves correctly */
-h1.anchor, h2.anchor, h3.anchor, h4.anchor {
-    display: block;
-    position: relative;
-    top: -100px;
-    visibility: hidden;
+/* Adds an invisible element before each target to offset for the navigation 
+   bar */
+.anchor::before {
+  content:"";
+  display:block;
+  height:50px; /* fixed header height*/
+  margin:-50px 0 0; /* negative fixed header height */
 }
 """
         if '!bquiz' in filestr:


### PR DESCRIPTION
The previous fix led to headings becoming invisible and offset 100 pixels up. 
This fix, however, seems to work without any side effects.