### PR TITLE
Adjustments for the Yeti theme

### DIFF
--- a/lib/doconce/html.py
+++ b/lib/doconce/html.py
@@ -2850,6 +2850,15 @@ pre { color: inherit; background-color: transparent; }
   margin:-50px 0 0; /* negative fixed header height */
 }
 """
+        if html_style.endswith('yeti'):
+            style_changes += """
+/* decrease vertical padding and increase font size */
+.dropdown-menu>li>a {
+  padding:4px 15px;
+  font-size: 14px;
+}
+"""
+
         if '!bquiz' in filestr:
         # Style for buttons for collapsing paragraphs
             style_changes += """


### PR DESCRIPTION
Decrease vertical padding and increase font size in the dropdown-menu of the Yeti theme. 
The font size is overridden by `bootstrap.min.css` though, but I think 14px is fitting.