### PR TITLE
Set filetype unknown if explicit envir

### DIFF
--- a/lib/doconce/doconce.py
+++ b/lib/doconce/doconce.py
@@ -1307,6 +1307,7 @@ def insert_code_from_file(filestr, format):
 
             # Check if the code environment is explicitly specified
             if 'envir=' in line:
+                filetype = "unknown"
                 m = re.search(r'envir=([a-zN0-9_-]+)', line)
                 if m:
                     code_envir = m.group(1).strip()


### PR DESCRIPTION
Currently doconce.py crashes at line 1466 if filetype is not set, which can be the case if envir is set explicitly. This commit sets the filetype to "unknown" in that case. This might not be the correct value for the filetype, but it avoids the crash.