### PR TITLE
convert .pdf to other formats when creating ipynb

### DIFF
--- a/lib/doconce/ipynb.py
+++ b/lib/doconce/ipynb.py
@@ -877,6 +877,6 @@ def define(FILENAME_EXTENSION,
     EXERCISE['ipynb'] = plain_exercise
     TOC['ipynb'] = lambda s, f: ''
     FIGURE_EXT['ipynb'] = {
-        'search': ('.png', '.gif', '.jpg', '.jpeg', '.tif', '.tiff', '.pdf'),
+        'search': ('.png', '.gif', '.jpg', '.jpeg', '.tif', '.tiff'),
         'convert': ('.png', '.gif', '.jpg')}
     QUIZ['ipynb'] = pandoc_quiz


### PR DESCRIPTION
Notebooks are unable to show pdf-figures by default. This fixes so pdf-figures are converted to supported formats when creating a notebook.