### PR TITLE
Make doconce compatible with both Python 2.7 and Python 3.6

### DIFF
--- a/_update.py
+++ b/_update.py
@@ -1,11 +1,13 @@
+from __future__ import print_function
+from builtins import input
 #!/usr/bin/env python
 import sys, os, shutil, glob
 
 def system(cmd):
-    print cmd
+    print(cmd)
     failure = os.system(cmd)
     if failure:
-        print 'could not run\n%s\nin%s' % (cmd, os.getcwd())
+        print('could not run\n%s\nin%s' % (cmd, os.getcwd()))
         sys.exit(1)
 
 def rmtree(directory):
@@ -66,7 +68,7 @@ def zipfiles2lib():
 
 def pack_reveal_deck_csss():
     if clone:
-        print """
+        print("""
 NOTE: cloning repos like reveal.js and deck.js may bring in new
 versions of styles that are not compatible with previous tuning.
 So, be careful to mix doconce tunings with new versions.
@@ -85,8 +87,8 @@ You should also diff with a fresh reveal.js clone to see how new
 
 (Detected time-consuming incompatibilities Jan, 2014, after reveal and
 deck had undergone significant developments.)
-"""
-        ans = raw_input('Sure you want to proceed? (y/n) ')
+""")
+        ans = input('Sure you want to proceed? (y/n) ')
         if ans.lower().startswith('n'):
             return
 
@@ -173,7 +175,7 @@ if __name__ == '__main__':
     os.system('rm -f *.zip')
 
     if len(sys.argv) == 1:
-        print 'Usage: python _update.py all | | all-noclone | local'
+        print('Usage: python _update.py all | | all-noclone | local')
         sys.exit(1)
     if sys.argv[1] == 'all':
         clone = True
@@ -186,4 +188,4 @@ if __name__ == '__main__':
         #eval(func + '()')
         pack_local_dirs()
 
-    print 'Successful execution of', sys.argv[0]
+    print('Successful execution of', sys.argv[0])

--- a/_update.py
+++ b/_update.py
@@ -1,6 +1,8 @@
 from __future__ import print_function
 from builtins import input
 #!/usr/bin/env python
+from __future__ import print_function
+from builtins import input
 import sys, os, shutil, glob
 
 def system(cmd):

--- a/bin/doconce
+++ b/bin/doconce
@@ -1,7 +1,12 @@
+from __future__ import print_function
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from builtins import range
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import os, sys
-from commands import getstatusoutput
+from subprocess import getstatusoutput
 from doconce.misc import system, misc_option, load_preprocessed_doconce_file
 from doconce.misc import (
     insertdocstr,
@@ -89,10 +94,10 @@ def format():
             doconce_lib = os.path.join(thisdir, os.pardir, 'lib', 'doconce')
             sys.path.insert(0, doconce_lib)
             import doconce.doconce
-            print 'Successfull import of doconce locally'
-        except ImportError, e:
-            print e
-            print 'Could not import doconce from directory\n', os.getcwd()
+            print('Successfull import of doconce locally')
+        except ImportError as e:
+            print(e)
+            print('Could not import doconce from directory\n', os.getcwd())
             sys.exit(1)
 
     bg_session = doconce.doconce.format_driver()
@@ -105,7 +110,7 @@ def format():
 # file...
 
 def _usage_sphinx_dir():
-    print """Usage: doconce sphinx_dir short-title="some short title" version=0.1 theme=themename dirname=sphinx-rootdir toc_depth=2 intersphinx  doconcefile [--runestone]
+    print("""Usage: doconce sphinx_dir short-title="some short title" version=0.1 theme=themename dirname=sphinx-rootdir toc_depth=2 intersphinx  doconcefile [--runestone]
 
 Additional command-line arguments: theme_dir=directoryname conf.py=filename logo=filename favicon=filename
 
@@ -165,7 +170,7 @@ The master file can be split into parts. Here is the typical code:
   python automake_sphinx.py
 
 Note that split_rst must be run prior to sphinx_dir!
-"""
+""")
 
 import time, shutil, glob, re  # used in sphinx_dir
 
@@ -226,22 +231,22 @@ def sphinx_dir():
             doconce_files.append(arg)
 
     if not doconce_files:
-        print 'must have (at least one) doconce file as argument'
-        print 'doconce sphinx_dir somefile.do.txt'
+        print('must have (at least one) doconce file as argument')
+        print('doconce sphinx_dir somefile.do.txt')
         sys.exit(1)
     try:
         import sphinx
     except ImportError:
-        print 'Unable to import sphinx. Install sphinx from sphinx.pocoo.org.'
-        print 'On Debian systems, install the \'python-sphinx\' package.'
+        print('Unable to import sphinx. Install sphinx from sphinx.pocoo.org.')
+        print('On Debian systems, install the \'python-sphinx\' package.')
         sys.exit(1)
     if float(sphinx.__version__[:3]) < 1.1:
-        print 'Abort: sphinx version >= 1.1 required'
+        print('Abort: sphinx version >= 1.1 required')
         sys.exit(1)
 
     if len(doconce_files) > 1:
-        print 'can only specify one main doconce file'
-        print '(here you have specified %s)' % ', '.join(doconce_files)
+        print('can only specify one main doconce file')
+        print('(here you have specified %s)' % ', '.join(doconce_files))
         sys.exit(1)
 
     filename = doconce_files[0]
@@ -249,7 +254,7 @@ def sphinx_dir():
         filename = filename[:-7]
     else:
         if not os.path.isfile(filename + '.do.txt'):
-            print '%s.do.txt does not exist' % filename
+            print('%s.do.txt does not exist' % filename)
             sys.exit(1)
 
     parts = glob.glob('._%s[0-9][0-9][0-9].rst' % filename)
@@ -263,7 +268,7 @@ def sphinx_dir():
                 title = line[6:].strip()
                 break # use the first TITLE spec
         if title_cml is not None:
-            print '*** error: cannot give title= on the command line when TITLE is specified in the DocOnce file', filename
+            print('*** error: cannot give title= on the command line when TITLE is specified in the DocOnce file', filename)
             sys.exit(1)
     else:
         # No TITLE in the DocOnce file
@@ -289,7 +294,7 @@ def sphinx_dir():
         else:
             author = ', '.join(author[:-1]) + ' and ' + author[-1]
         if author_cml is not None:
-            print '*** error: cannot give author= on the command line when AUTHOR is specified in the DocOnce file', filename
+            print('*** error: cannot give author= on the command line when AUTHOR is specified in the DocOnce file', filename)
             sys.exit(1)
     else:
         if author_cml is None:
@@ -326,7 +331,7 @@ def sphinx_dir():
             copyright_ = copyright_cml
     else:
         if copyright_cml is not None:
-            print '*** error: cannot give copyright= on the command line when {coppyright...} is specified as part of AUTHOR in the DocOnce file', filename
+            print('*** error: cannot give copyright= on the command line when {coppyright...} is specified as part of AUTHOR in the DocOnce file', filename)
             sys.exit(1)
 
     chapters = '=========' in fstr
@@ -334,15 +339,15 @@ def sphinx_dir():
         toc_depth += 1
 
     if theme_dir is not None and conf_py is None:
-        print 'theme_dir is given, but then also conf_py must be specified'
-        print 'Abort!'
+        print('theme_dir is given, but then also conf_py must be specified')
+        print('Abort!')
         sys.exit(1)
 
-    print 'title:', title
-    print 'author:', author
-    print 'copyright:', copyright_
-    print 'theme:', theme
-    print
+    print('title:', title)
+    print('author:', author)
+    print('copyright:', copyright_)
+    print('theme:', theme)
+    print()
     time.sleep(1.5)
 
     #make_conf_py_runestone(themes, theme, title, short_title,
@@ -483,7 +488,7 @@ EOF
                   sphinx_basic_themes + sphinx_installed_themes
 
         if conf_py is None:
-            print 'These Sphinx themes were found:', ', '.join(sorted(themes))
+            print('These Sphinx themes were found:', ', '.join(sorted(themes)))
             make_conf_py(themes, theme, title, short_title, copyright_,
                          logo, favicon, intersphinx)
     else:
@@ -573,7 +578,7 @@ echo "for i in sphinx-*; do google-chrome $i/index.html; done"
 
 """ % (' '.join(themes)))
     f.close()
-    os.chmod('make_themes.sh', 0755)
+    os.chmod('make_themes.sh', 0o755)
 
     # Make index.rst main file for the document
     f = open('index.rst', 'w')
@@ -931,14 +936,14 @@ google-chrome %(sphinx_rootdir)s/RunestoneTools/build/index.html
 """
 ''' % vars())
     f.close()
-    os.chmod('automake_sphinx.py', 0755)
-    print """
+    os.chmod('automake_sphinx.py', 0o755)
+    print("""
 'automake_sphinx.py' contains the steps to (re)compile the sphinx
 version. You may want to edit this file, or run the steps manually,
 or just run it by
 
   python automake_sphinx.py
-"""
+""")
     # Add scrollbars to navigation bar dropdown menu in case of bootstrap
     # (this css style is already written to index.rst)
     if 'bootstrap' in theme:
@@ -1491,7 +1496,7 @@ fix_bibtex4publish
 # -----------------------------------------------------------------------
 
 def help():
-    print r"""
+    print(r"""
 
 # transform doconce file to another format
 doconce format html|latex|pdflatex|rst|sphinx|plain|gwiki|mwiki|cwiki|pandoc|st|epytext dofile
@@ -1664,7 +1669,7 @@ doconce expand_commands file1 file2 ...
 
 # insert a table of exercises in a latex file myfile.p.tex
 doconce latex_exercise_toc myfile
-"""
+""")
 #doconce teamod name
 #doconce assemble name master.do.txt
 
@@ -1675,13 +1680,13 @@ def main():
         help_format()
         sys.exit(0)
     if len(sys.argv) == 1 or misc_option('help'):
-        print 'DocOnce version', version
-        print 'Usage: doconce command [optional arguments]'
-        print 'commands: %s' % (' '.join(commands))
+        print('DocOnce version', version)
+        print('Usage: doconce command [optional arguments]')
+        print('commands: %s' % (' '.join(commands)))
         help()
         sys.exit(0)
     if misc_option('version'):
-        print 'DocOnce version', version
+        print('DocOnce version', version)
         sys.exit(0)
 
     command = sys.argv[1]
@@ -1692,10 +1697,10 @@ def main():
         # For backward compatibility:
         if len(sys.argv) >= 2 and sys.argv[1] == 'LaTeX':
             sys.argv[1] = 'latex'
-            print '\nWarning: Previous format LaTeX now has the name latex\n'
+            print('\nWarning: Previous format LaTeX now has the name latex\n')
         if len(sys.argv) >= 2 and sys.argv[1] == 'HTML':
             sys.argv[1] = 'html'
-            print '\nWarning: Previous format HTML now has the name html\n'
+            print('\nWarning: Previous format HTML now has the name html\n')
 
     # Treat wrong command name
     found = False
@@ -1706,14 +1711,14 @@ def main():
     if not found:
         if command in ('html', 'latex', 'sphinx', 'rst', 'plain', 'gwiki', \
            'mwiki', 'epydoc', 'pandoc'):
-            print 'command', command, 'is not a legal command for doconce, did you mean'
-            print 'doconce format %s %s?' % (command, ' '.join(sys.argv[1:]))
+            print('command', command, 'is not a legal command for doconce, did you mean')
+            print('doconce format %s %s?' % (command, ' '.join(sys.argv[1:])))
         else:
-            print 'command "%s" is not legal, must be among\n' % command
-            print ', '.join(commands)
+            print('command "%s" is not legal, must be among\n' % command)
+            print(', '.join(commands))
     return retval
 
 bg_session = main()
 if bg_session is not None:
-    print '...running bokeh bg_session.loop_until_closed() in the background'
+    print('...running bokeh bg_session.loop_until_closed() in the background')
     bg_session.loop_until_closed()

--- a/bin/doconce
+++ b/bin/doconce
@@ -1,10 +1,10 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 from __future__ import print_function
 from future import standard_library
 standard_library.install_aliases()
 from builtins import str
 from builtins import range
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
 import os, sys
 from subprocess import getstatusoutput
 from doconce.misc import system, misc_option, load_preprocessed_doconce_file

--- a/doc/src/blog/Runges_func.py
+++ b/doc/src/blog/Runges_func.py
@@ -1,6 +1,9 @@
+from __future__ import division
+from __future__ import print_function
+from past.utils import old_div
 def f(x):
     """Runge's function."""
-    return 1/(1 + x**2)
+    return old_div(1,(1 + x**2))
 
 # Plot f
 import matplotlib.pyplot as plt
@@ -14,9 +17,9 @@ plt.savefig('f_plot.png')
 import sympy as sm
 x = sm.Symbol('x')
 f_expr = f(x)
-print f_expr
+print(f_expr)
 df_expr = sm.diff(f_expr, x)
-print df_expr
+print(df_expr)
 df = sm.lambdify(x, df_expr)  # turn expression into Python function
 
 # Plot f'(x)

--- a/doc/src/html-font-demo/test_fonts.py
+++ b/doc/src/html-font-demo/test_fonts.py
@@ -1,10 +1,13 @@
-import commands, os, shutil
+from __future__ import print_function
+from future import standard_library
+standard_library.install_aliases()
+import subprocess, os, shutil
 
-failure, output = commands.getstatusoutput('doconce format html report --html-body-font=?')
+failure, output = subprocess.getstatusoutput('doconce format html report --html-body-font=?')
 fonts = output.splitlines()[-1].split()
 
 for font in fonts:
-    print font
+    print(font)
     font2 = font.replace('+', ' ')
     os.system('doconce format html report --html-body-font=%s --html-heading-font=%s --html-style=bloodish BODY_FONT="%s" HEADING_FONT="%s"' % (font, font, font2, font2))
     shutil.copy('report.html', 'report_%s_%s.html' % (font, font))

--- a/doc/src/ipynb/ipynb_generator.py
+++ b/doc/src/ipynb/ipynb_generator.py
@@ -58,6 +58,10 @@ Results in the notebook myfile.ipynb.
 All you need is this file - no dependencies except Python version 2.7
 and the numpy and sympy modules for running the example.
 """
+from __future__ import print_function
+from builtins import zip
+from builtins import str
+from builtins import range
 __author__ = 'Hans Petter Langtangen <hpl@simula.no>'
 
 import sys, os, re, logging
@@ -94,7 +98,7 @@ def read(text, argv=sys.argv[2:]):
         import mako
         has_mako = True
     except ImportError:
-        print 'Cannot import mako - mako is not run'
+        print('Cannot import mako - mako is not run')
         has_mako = False
 
     if has_mako:
@@ -102,7 +106,7 @@ def read(text, argv=sys.argv[2:]):
         from mako.lookup import TemplateLookup
         lookup = TemplateLookup(directories=[os.curdir])
 
-        text = unicode(text, encoding)
+        text = str(text, encoding)
         temp = Template(text=text, lookup=lookup,
                         strict_undefined=True)
         logging.info('******* mako_kwargs: %s' % str(mako_kwargs))
@@ -219,8 +223,8 @@ def driver():
         with open(filename, 'r') as f:
             text = f.read()
     except (IndexError, IOError) as e:
-        print 'Usage: %s filename' % (sys.argv[0])
-        print e
+        print('Usage: %s filename' % (sys.argv[0]))
+        print(e)
         sys.exit(1)
     cells = read(text, argv=sys.argv[2:])
     filestr = write(cells, 3)
@@ -239,14 +243,14 @@ def test_notebook_generator():
     logging.info('******* original text:\n%s' % text)
     cells = read(text, argv=argv)
     computed = write(cells, 3).strip()
-    print computed
+    print(computed)
 
     with open('.test1.ipynb', 'r') as f:
         expected = f.read().strip()
 
-    for c1, c2, n in zip(computed, expected, range(len(expected))):
+    for c1, c2, n in zip(computed, expected, list(range(len(expected)))):
         if c1 != c2:
-            print 'character no.%d differ: %s vs %s' % (n, c1, c2)
+            print('character no.%d differ: %s vs %s' % (n, c1, c2))
     assert computed == expected
 
 if __name__ == '__main__':

--- a/doc/src/ipynb/ipynb_generator_v4.py
+++ b/doc/src/ipynb/ipynb_generator_v4.py
@@ -1,3 +1,7 @@
+from __future__ import print_function
+from builtins import zip
+from builtins import str
+from builtins import range
 import sys, os, re
 
 # Mapping of shortnames like py to full language
@@ -31,7 +35,7 @@ def read(text, argv=sys.argv[2:]):
         import mako
         has_mako = True
     except ImportError:
-        print 'Cannot import mako - mako is not run'
+        print('Cannot import mako - mako is not run')
         has_mako = False
 
     if has_mako:
@@ -39,7 +43,7 @@ def read(text, argv=sys.argv[2:]):
         from mako.lookup import TemplateLookup
         lookup = TemplateLookup(directories=[os.curdir])
 
-        text = unicode(text, encoding)
+        text = str(text, encoding)
         temp = Template(text=text, lookup=lookup,
                         strict_undefined=True)
         text = temp.render(**mako_kwargs)
@@ -121,8 +125,8 @@ def driver():
         with open(filename, 'r') as f:
             text = f.read()
     except (IndexError, IOError) as e:
-        print 'Usage: %s filename' % (sys.argv[0])
-        print e
+        print('Usage: %s filename' % (sys.argv[0]))
+        print(e)
         sys.exit(1)
     cells = read(text, argv=sys.argv[2:])
     filestr = write(cells, 3)
@@ -139,14 +143,14 @@ def test_notebook_generator():
         text = f.read()
     cells = read(text, argv=argv)
     computed = write(cells, 3).strip()
-    print computed
+    print(computed)
 
     with open('.test1.ipynb', 'r') as f:
         expected = f.read().strip()
 
-    for c1, c2, n in zip(computed, expected, range(len(expected))):
+    for c1, c2, n in zip(computed, expected, list(range(len(expected)))):
         if c1 != c2:
-            print 'character no.%d differ: %s vs %s' % (n, c1, c2)
+            print('character no.%d differ: %s vs %s' % (n, c1, c2))
     assert computed == expected
 
 if __name__ == '__main__':

--- a/doc/src/ipynb/src/solver.py
+++ b/doc/src/ipynb/src/solver.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from builtins import range
+from past.utils import old_div
 import numpy as np
 
 def solver(I, V, m, b, s, F, t, damping='linear'):
@@ -35,12 +38,12 @@ def solver(I, V, m, b, s, F, t, damping='linear'):
 
     for n in range(1,N):
         if damping == 'linear':
-            u[n+1] = (2*m*u[n] + (b*dt/2 - m)*u[n-1] +
-                      dt**2*(F[n] - s(u[n])))/(m + b*dt/2)
+            u[n+1] = old_div((2*m*u[n] + (b*dt/2 - m)*u[n-1] +
+                      dt**2*(F[n] - s(u[n]))),(m + b*dt/2))
         elif damping == 'quadratic':
-            u[n+1] = (2*m*u[n] - m*u[n-1] + b*u[n]*abs(u[n] - u[n-1])
-                      - dt**2*(s(u[n]) - F[n]))/\
-                      (m + b*abs(u[n] - u[n-1]))
+            u[n+1] = old_div((2*m*u[n] - m*u[n-1] + b*u[n]*abs(u[n] - u[n-1])
+                      - dt**2*(s(u[n]) - F[n])),\
+                      (m + b*abs(u[n] - u[n-1])))
     return u, t
 
 # Simplified implementation

--- a/doc/src/latexcode/fileread.py
+++ b/doc/src/latexcode/fileread.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import numpy as np
 
 def readfile(filename):
@@ -21,9 +22,9 @@ if __name__ == '__main__':
     data = readfile('mydat.txt')
     # Treat each column as a variable
     m, s, c = analyze(data.transpose())
-    print """
+    print("""
 mean=%f
 st.dev=%f
 correlation matrix:
 %s
-""" % (m, s, c)
+""" % (m, s, c))

--- a/doc/src/manual/_all_code.p.py
+++ b/doc/src/manual/_all_code.p.py
@@ -7,4 +7,5 @@
 # #include "more_functions.py"
 
 # Test the code included above
-print some_func(1, 'arg')
+from __future__ import print_function
+print(some_func(1, 'arg'))

--- a/doc/src/manual/bokeh_demo.py
+++ b/doc/src/manual/bokeh_demo.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from builtins import range
+from past.utils import old_div
 
 def bokeh_plot(u, t, legends, u_e, t_e, I, w, t_range, filename):
     """
@@ -57,7 +60,7 @@ def demo_bokeh():
         return I*np.cos(w*t)
 
     def u_numerical(t):
-        w_tilde = (2./dt)*np.arcsin(w*dt/2.)
+        w_tilde = (old_div(2.,dt))*np.arcsin(w*dt/2.)
         return I*np.cos(w_tilde*t)
 
     I = 1               # Amplitude
@@ -75,7 +78,7 @@ def demo_bokeh():
 
     # Make a series of numerical solutions with different time steps
     for n in num_steps_per_period:
-        dt = P/n  # Time step length
+        dt = old_div(P,n)  # Time step length
         t_ = np.linspace(0, T, num_periods*n+1)
         u_ = u_numerical(t_)
         u.append(u_)

--- a/doc/src/manual/deb2sh.py
+++ b/doc/src/manual/deb2sh.py
@@ -13,6 +13,7 @@ File syntax:
    by sudo apt-get install packagename.
 
 """
+from __future__ import print_function
 import sys
 try:
     debpkg = sys.argv[1]
@@ -147,5 +148,5 @@ shfile.write('echo "Everything is successfully installed!"\n')
 shfile.close()
 pyfile.write("print 'Everything is successfully installed!'\n")
 pyfile.close()
-print 'Generated %s.sh and %s.py with all install commands.' % \
-      (outfile, outfile)
+print('Generated %s.sh and %s.py with all install commands.' % \
+      (outfile, outfile))

--- a/doc/src/manual/install_doconce.py
+++ b/doc/src/manual/install_doconce.py
@@ -6,6 +6,7 @@
 
 # The script is based on packages listed in debpkg_doconce.txt.
 
+from __future__ import print_function
 logfile = 'tmp_output.log'  # store all output of all operating system commands
 f = open(logfile, 'w'); f.close()  # touch logfile so it can be appended
 
@@ -13,16 +14,16 @@ import subprocess, sys
 
 def system(cmd):
     """Run system command cmd."""
-    print cmd
+    print(cmd)
     try:
         output = subprocess.check_output(cmd, shell=True,
                                          stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as e:
-        print 'Command\n  %s\nfailed.' % cmd
-        print 'Return code:', e.returncode
-        print e.output
+        print('Command\n  %s\nfailed.' % cmd)
+        print('Return code:', e.returncode)
+        print(e.output)
         sys.exit(1)
-    print output
+    print(output)
     f = open(logfile, 'a'); f.write(output); f.close()
 
 system('sudo apt-get update --fix-missing')
@@ -170,4 +171,4 @@ system('sudo apt-get -y install diffuse')
 # example on installing mdframed.sty manually (it exists in texlive,
 # but sometimes needs to be in its newest version)
 
-print 'Everything is successfully installed!'
+print('Everything is successfully installed!')

--- a/doc/src/pyembed/src/ex1.py
+++ b/doc/src/pyembed/src/ex1.py
@@ -1,10 +1,11 @@
+from __future__ import print_function
 import sympy as sm
 x, y, a = sm.symbols('x y a')
 f = a*x + y**2*sm.sin(y)
 step1 = sm.Integral(f, x, y)
-print step1
+print(step1)
 step2 = sm.Integral(sm.Integral(f, x).doit(), y)
-print step2
+print(step2)
 step3 = step2.doit()
-print step3
+print(step3)
 

--- a/doc/src/quiz/addspace.py
+++ b/doc/src/quiz/addspace.py
@@ -2,6 +2,7 @@
 Add space(s) at the beginning of all lines in a file to allow
 the html code not to be interpreted as quizes inside !bc/!ec tags.
 """
+from __future__ import print_function
 import sys
 f = open(sys.argv[1], 'r')
 try:
@@ -9,5 +10,5 @@ try:
 except IndexError:
     spaces = 1
 for line in f.read().splitlines():
-    print ' '*spaces, line
+    print(' '*spaces, line)
 

--- a/doc/src/slides/generate.py
+++ b/doc/src/slides/generate.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # NOTE: This is a program used to test all slides styles in all combinations.
 # Fine for new slide environments, but optimal combinations are what
 # a user needs, not all combinations.
@@ -7,10 +8,10 @@
 import os, shutil, sys
 
 def system(cmd):
-    print cmd
+    print(cmd)
     failure = os.system(cmd)
     if failure:
-        print 'could not run', cmd
+        print('could not run', cmd)
         sys.exit(1)
 
 from collections import OrderedDict as dict

--- a/doc/src/slides/src/solver.py
+++ b/doc/src/slides/src/solver.py
@@ -1,3 +1,7 @@
+from __future__ import division
+from __future__ import print_function
+from builtins import range
+from past.utils import old_div
 from numpy import *
 from matplotlib.pyplot import *
 import sys
@@ -5,7 +9,7 @@ import sys
 def solver(I, a, T, dt, theta):
     """Solve u'=-a*u, u(0)=I, for t in (0,T]; step: dt."""
     dt = float(dt)           # avoid integer division
-    N = int(round(T/dt))     # no of time intervals
+    N = int(round(old_div(T,dt)))     # no of time intervals
     T = N*dt                 # adjust T to fit time step dt
     u = zeros(N+1)           # array of u[n] values
     t = linspace(0, T, N+1)  # time mesh
@@ -65,13 +69,13 @@ def read_command_line(use_argparse=True):
     if use_argparse:
         parser = define_command_line_options()
         args = parser.parse_args()
-        print 'I={}, a={}, makeplot={}, dt_values={}'.format(
-            args.I, args.a, args.makeplot, args.dt_values)
+        print('I={}, a={}, makeplot={}, dt_values={}'.format(
+            args.I, args.a, args.makeplot, args.dt_values))
         return args.I, args.a, args.T, args.makeplot, args.dt_values
     else:
         if len(sys.argv) < 6:
-            print 'Usage: %s I a on/off dt1 dt2 dt3 ...' % \
-                  sys.argv[0]; sys.exit(1)
+            print('Usage: %s I a on/off dt1 dt2 dt3 ...' % \
+                  sys.argv[0]); sys.exit(1)
 
         I = float(sys.argv[1])
         a = float(sys.argv[2])
@@ -92,13 +96,13 @@ def main():
 
         # Compute convergence rates
         m = len(dt_values)
-        r[theta] = [log(E_values[i-1]/E_values[i])/
-                    log(dt_values[i-1]/dt_values[i])
+        r[theta] = [old_div(log(old_div(E_values[i-1],E_values[i])),
+                    log(old_div(dt_values[i-1],dt_values[i])))
                     for i in range(1, m, 1)]
 
     for theta in r:
-        print '\nPairwise convergence rates for theta=%g:' % theta
-        print ' '.join(['%.2f' % r_ for r_ in r[theta]])
+        print('\nPairwise convergence rates for theta=%g:' % theta)
+        print(' '.join(['%.2f' % r_ for r_ in r[theta]]))
     return r
 
 def verify_convergence_rate():
@@ -116,12 +120,12 @@ if __name__ == '__main__':
     if 'verify_rates' in sys.argv:
         sys.argv.remove('verify_rates')
         if not '--dt' in sys.argv:
-            print 'Must assign several dt values through the --dt option'
+            print('Must assign several dt values through the --dt option')
             sys.exit(1)  # abort
         if verify_convergence_rate():
             pass
         else:
-            print 'Bug in the implementation!'
+            print('Bug in the implementation!')
     else:
         # Perform simulations
         main()

--- a/lib/doconce/DocWriter.py
+++ b/lib/doconce/DocWriter.py
@@ -788,7 +788,7 @@ def html_movie(plotfiles, interval_ms=300, width=800, height=600,
 
     # Start with expanding plotfiles if it is a filename generator
     if not isinstance(plotfiles, (tuple,list)):
-        if not isinstance(plotfiles, str):
+        if not isinstance(plotfiles, basestring):
             raise TypeError('plotfiles must be list or filename generator, not %s' % type(plotfiles))
 
         filename_generator = plotfiles

--- a/lib/doconce/DocWriter.py
+++ b/lib/doconce/DocWriter.py
@@ -9,11 +9,19 @@ write to) various formats.
 
 This module works, but is unifinished and needs documentation!
 """
+from __future__ import print_function
+from future import standard_library
+standard_library.install_aliases()
+from builtins import zip
+from builtins import str
+from builtins import range
+from past.builtins import basestring
+from builtins import object
 
-from StringIO import StringIO
+from io import StringIO
 import re, os, glob, subprocess
 
-class _BaseWriter:
+class _BaseWriter(object):
     """
     Base class for document writing classes.
     Each subclass implements a specific format (html, latex,
@@ -58,9 +66,8 @@ class _BaseWriter:
         pass
 
     def not_impl(self, method):
-        raise NotImplementedError, \
-              'method "%s" in class "%s" is not implemented' % \
-              (method, self.__class__.__name__)
+        raise NotImplementedError('method "%s" in class "%s" is not implemented' % \
+              (method, self.__class__.__name__))
 
     def title(self, title, authors_and_institutions=[], date='today'):
         """
@@ -174,9 +181,9 @@ class _BaseWriter:
         """
         # check for common error (a trailing comma...):
         if isinstance(items, tuple) and len(items) == 1:
-            raise ValueError, 'list is a 1-tuple, error? If there is '\
+            raise ValueError('list is a 1-tuple, error? If there is '\
                   'only one item in the list, make a real Python list '\
-                  'object instead - current list is\n(%s,)' % items
+                  'object instead - current list is\n(%s,)' % items)
         item_handler('_begin', listtype, level)
         for i, item in enumerate(items):
             if isinstance(item, (list,tuple)):
@@ -191,7 +198,7 @@ class _BaseWriter:
                 else:
                     item_handler(item, listtype, level)
             else:
-                raise TypeError, 'wrong %s for item' % type(item)
+                raise TypeError('wrong %s for item' % type(item))
         item_handler('_end', listtype, level)
 
     def item_handler(self, item, listtype, level, keyword=None):
@@ -248,20 +255,20 @@ class _BaseWriter:
             stem, ext = os.path.splitext(file)
             if ext == '.ps' or ext == '.eps':
                 cmd = 'convert %s %s' % (file, final)
-                print cmd
+                print(cmd)
                 failure = os.system(cmd)
                 if failure:
-                    print 'Could not convert;\n  %s' % cmd
+                    print('Could not convert;\n  %s' % cmd)
                 return final
         # try to convert from the first file to the disired format:
         file = files[0]
         cmd = 'convert %s %s' % (file, final)
-        print cmd
+        print(cmd)
         try:
             output = subprocess.check_output(cmd, shell=True,
                                              stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:
-            print 'Could not convert;\n  %s' % cmd
+            print('Could not convert;\n  %s' % cmd)
         return final
 
     def figure(self, filename, caption, width=None, height=None, label=None):
@@ -633,15 +640,14 @@ class HTML(_BaseWriter):
 
 class LaTeX(_BaseWriter):
     def __init__(self):
-        raise NotImplementedError, \
-              'Use DocOnce class instead and filter to LaTeX'
+        raise NotImplementedError('Use DocOnce class instead and filter to LaTeX')
 
 # Efficient way of generating class DocWriter.
 # A better way (for pydoc and other API references) is to
 # explicitly list all methods and their arguments and then add
 # the body for writer in self.writers: writer.method(arg1, arg2, ...)
 
-class DocWriter:
+class DocWriter(object):
     """
     DocWriter can write documents in several formats at once.
     """
@@ -723,7 +729,7 @@ def _%s:
 func_to_method(_%s, DocWriter, '%s')
 """ % (signature_def, docstring, signature_call, method, method)
     #print 'Autogenerating\n', code
-    exec code
+    exec(code)
 
 def html_movie(plotfiles, interval_ms=300, width=800, height=600,
                casename=None):
@@ -782,7 +788,7 @@ def html_movie(plotfiles, interval_ms=300, width=800, height=600,
 
     # Start with expanding plotfiles if it is a filename generator
     if not isinstance(plotfiles, (tuple,list)):
-        if not isinstance(plotfiles, (str,unicode)):
+        if not isinstance(plotfiles, str):
             raise TypeError('plotfiles must be list or filename generator, not %s' % type(plotfiles))
 
         filename_generator = plotfiles
@@ -994,8 +1000,8 @@ width="%(width)s" height="%(height)s" autoplay="false">
 
 def _test(d):
     # d is formatclass() or DocWriter(HTML, LaTeX, ...)
-    print '\n\n', '*'*70, \
-          '\n*** Testing class "%s"\n' % d.__class__.__name__, '*'*70
+    print('\n\n', '*'*70, \
+          '\n*** Testing class "%s"\n' % d.__class__.__name__, '*'*70)
 
     d.title('My Test of Class %s' % d.__class__.__name__,
             [('Hans Petter Langtangen',
@@ -1064,7 +1070,7 @@ b.item = 0  # create a new attribute
     d.paragraph_separator()
     d.text('And here is a table:')
     d.table([['a', 'b'], ['c', 'd'], ['e', 'and a longer text']])
-    print d
+    print(d)
     d.write_to_file('tmp_%s' % d.__class__.__name__)
 
 if __name__ == '__main__':

--- a/lib/doconce/__init__.p.py
+++ b/lib/doconce/__init__.p.py
@@ -3,6 +3,7 @@
 # #include "docstrings/docstring.dst.txt"
 
 '''
+from __future__ import absolute_import
 
 __version__ = '1.3'
 version = __version__
@@ -11,4 +12,4 @@ author = __author__
 
 __acknowledgments__ = ''
 
-from doconce import doconce_format, DocOnceSyntaxError
+from .doconce import doconce_format, DocOnceSyntaxError

--- a/lib/doconce/__init__.py
+++ b/lib/doconce/__init__.py
@@ -85,6 +85,7 @@ Documentation of DocOnce is found in
 Both directories contain a make.sh file for creating various formats.
 
 '''
+from __future__ import absolute_import
 
 __version__ = '1.3'
 version = __version__
@@ -93,4 +94,4 @@ author = __author__
 
 __acknowledgments__ = ''
 
-from doconce import doconce_format, DocOnceSyntaxError
+from .doconce import doconce_format, DocOnceSyntaxError

--- a/lib/doconce/common.py
+++ b/lib/doconce/common.py
@@ -4,9 +4,14 @@ DocOnce format to other formats.  Some convenience functions used in
 translation modules (latex.py, html.py, etc.) are also included in
 here.
 """
-import re, sys, urllib, os, shutil, subprocess#, xml.etree.ElementTree
-from misc import option, _abort
-from doconce import errwarn, locale_dict
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from builtins import range
+import re, sys, urllib.request, urllib.parse, urllib.error, os, shutil, subprocess#, xml.etree.ElementTree
+from .misc import option, _abort
+from .doconce import errwarn, locale_dict
 
 format = None   # latex, pdflatex, html, plain, etc
 
@@ -52,15 +57,15 @@ _counter_for_html_movie_player = 0
 
 def internet_access(timeout=1):
     """Return True if internet is on, else False."""
-    import urllib2, socket
+    import urllib.request, urllib.error, urllib.parse, socket
     try:
         # Check google.com with numerical IP-address (which avoids
         # DNS loopup) and set timeout to 1 sec so this does not
         # take much time (google.com should respond quickly)
        #response = urllib2.urlopen('http://8.8.8.8', timeout=timeout)
-       response = urllib2.urlopen('http://vg.no', timeout=timeout)
+       response = urllib.request.urlopen('http://vg.no', timeout=timeout)
        return True
-    except (urllib2.URLError, socket.timeout) as err:
+    except (urllib.error.URLError, socket.timeout) as err:
         pass
     return False
 
@@ -68,7 +73,7 @@ def safe_join(lines, delimiter):
     try:
         filestr = delimiter.join(lines) + '\n' # will fail if ord(char) > 127
         return filestr
-    except UnicodeDecodeError, e:
+    except UnicodeDecodeError as e:
         if "'ascii' codec can't decode":
             errwarn('*** error: non-ascii character - rerun with --encoding=utf-8')
             _abort()
@@ -125,8 +130,8 @@ def is_file_or_url(filename, msg='checking existence of', debug=True):
             # Print a message in case the program hangs a while here
             if msg is not None or debug:
                 errwarn('... ' +  msg + ' ' +  filename + ' ...')
-            import urllib2
-            f = urllib2.urlopen(filename, timeout=10)
+            import urllib.request, urllib.error, urllib.parse
+            f = urllib.request.urlopen(filename, timeout=10)
             text = f.read()
             f.close()
             ext = os.path.splitext(filename)[1]
@@ -160,7 +165,7 @@ def is_file_or_url(filename, msg='checking existence of', debug=True):
                     if msg or debug:
                         errwarn('    found!')
                     return 'url'
-        except IOError, e:
+        except IOError as e:
             if msg or debug:
                 errwarn('    not found!')
             #if debug:  # not necessary
@@ -191,7 +196,7 @@ def get_copyfile_info(filestr=None, copyright_filename=None, format=None):
     # Copyright info
     cr_text = None
     if copyright_filename is None:
-        from doconce import dofile_basename
+        from .doconce import dofile_basename
         cr_filename = '.' + dofile_basename + '.copyright'
     else:
         cr_filename = copyright_filename
@@ -359,9 +364,9 @@ def online_python_tutor(code, return_tp='iframe'):
     (return_tp is 'iframe') for code embedded in
     on pythontutor.com.
     """
-    codestr = urllib.quote_plus(code.strip())
+    codestr = urllib.parse.quote_plus(code.strip())
     if return_tp == 'iframe':
-        urlprm = urllib.urlencode({'py': 2,
+        urlprm = urllib.parse.urlencode({'py': 2,
                                    'curInstr': 0,
                                    'cumulative': 'false'})
         iframe = """\
@@ -479,7 +484,7 @@ def default_movie(m):
     global _counter_for_html_movie_player
     filename = m.group('filename')
     caption = m.group('caption').strip()
-    from html import html_movie
+    from .html import html_movie
     text = html_movie(m)
 
     # Make an HTML file where the movie file can be played
@@ -769,7 +774,7 @@ def insert_code_and_tex(filestr, code_blocks, tex_blocks, format,
            - !bc and !ec inside code blocks - replace by |bc and |ec
     (run doconce on each individual file to locate the problem, then on
      smaller and smaller parts of each file)""")
-        numbers = range(len(code_blocks))  # expected numbers in code blocks
+        numbers = list(range(len(code_blocks)))  # expected numbers in code blocks
         for e in code_lines:
             # remove number
             number = int(e.split()[0])
@@ -794,7 +799,7 @@ def insert_code_and_tex(filestr, code_blocks, tex_blocks, format,
      smaller and smaller parts of each file)""")
         _abort()
 
-    from misc import option
+    from .misc import option
     max_linelength = option('max_bc_linelength=', None)
     if max_linelength is not None:
         max_linelength = int(max_linelength)
@@ -1149,7 +1154,7 @@ def bibliography(pubdata, citations, format='doconce'):
     in the ordered dictionary ``citations`` (``pubdata`` is a list
     of dicts loaded from a Publish database file).
     """
-    import publish_doconce
+    from . import publish_doconce
     if format == 'doconce':
         formatter = publish_doconce.doconce_format
     elif format in ('rst', 'sphinx'):

--- a/lib/doconce/cwiki.py
+++ b/lib/doconce/cwiki.py
@@ -2,13 +2,15 @@
 Creole Wiki (as used on bitbucket.org).
 See http://www.wikicreole.org/wiki/Creole1.0 for syntax.
 """
+from __future__ import absolute_import
+from builtins import zip
 # Simple edit of gwiki.py
 
 import re, os, sys, subprocess
-from common import default_movie, plain_exercise, insert_code_and_tex
-from plaintext import plain_quiz
-from misc import _abort
-from doconce import errwarn
+from .common import default_movie, plain_exercise, insert_code_and_tex
+from .plaintext import plain_quiz
+from .misc import _abort
+from .doconce import errwarn
 
 def cwiki_code(filestr, code_blocks, code_block_types,
                tex_blocks, format):
@@ -51,7 +53,7 @@ def cwiki_figure(m):
     result = r"""{{%s|%s}}""" % (filename, caption)
     return result
 
-from common import table_analysis
+from .common import table_analysis
 
 def cwiki_table(table):
     """Native Creole wiki table."""
@@ -106,7 +108,7 @@ def cwiki_author(authors_and_institutions, auth2index,
     # we skip institutions in Creole wiki
     return text
 
-from gwiki import wiki_ref_and_label_common
+from .gwiki import wiki_ref_and_label_common
 
 def cwiki_ref_and_label(section_label2title, format, filestr):
     return wiki_ref_and_label_common(section_label2title, format, filestr)
@@ -202,7 +204,7 @@ def define(FILENAME_EXTENSION,
         'search': ('.png', '.gif', '.jpg', '.jpeg'),
         'convert': ('.png', '.gif', '.jpg')}
     CROSS_REFS['cwiki'] = cwiki_ref_and_label
-    from plaintext import plain_index_bib
+    from .plaintext import plain_index_bib
     EXERCISE['cwiki'] = plain_exercise
     INDEX_BIB['cwiki'] = plain_index_bib
     TOC['cwiki'] = lambda s, f: '<<TableOfContents>>'

--- a/lib/doconce/doconce.py
+++ b/lib/doconce/doconce.py
@@ -1,3 +1,12 @@
+from __future__ import print_function
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import zip
+from builtins import chr
+from builtins import str
+from builtins import range
+from past.builtins import basestring
 # -*- coding: utf-8 -*-
 global dofile_basename
 
@@ -149,9 +158,9 @@ def _rmdolog():
 def errwarn(msg, newline=True):
     """Function for reporting errors and warnings to screen and file."""
     if newline:
-        print msg
+        print(msg)
     else:
-        print msg,
+        print(msg, end=' ')
     logfilename = dofile_basename + '.dlog'
     mode = 'a' if os.path.isfile(logfilename) else 'w'
     if encoding:
@@ -164,9 +173,9 @@ def errwarn(msg, newline=True):
     if newline:
         err.write('\n')
 
-from common import *
-from misc import option, which, _abort
-import html, latex, pdflatex, rst, sphinx, st, epytext, plaintext, gwiki, mwiki, cwiki, pandoc, ipynb, matlabnb
+from .common import *
+from .misc import option, which, _abort
+from . import html, latex, pdflatex, rst, sphinx, st, epytext, plaintext, gwiki, mwiki, cwiki, pandoc, ipynb, matlabnb
 
 def supported_format_names():
     return 'html', 'latex', 'pdflatex', 'rst', 'sphinx', 'st', 'epytext', 'plain', 'gwiki', 'mwiki', 'cwiki', 'pandoc', 'ipynb', 'matlabnb'
@@ -301,13 +310,13 @@ def markdown2doconce(filestr, format=None, ipynb_mode=False):
     quote_envir = 'quote'
     quote_envir = 'block'
 
-    from common import inline_tag_begin, inline_tag_end
+    from .common import inline_tag_begin, inline_tag_end
     extended_markdown_language2dolang = dict(
         Python='py', Ruby='rb', Fortran='f', Cpp='cpp', C='c',
         Perl='pl', Bash='sh', HTML='html')
 
     bc_postfix = '-t' if ipynb_mode else ''
-    from common import unindent_lines
+    from .common import unindent_lines
     regex = [
         # Computer code with language specification
         (r"\n?```([A-Za-z]+)(.*?)\n```", lambda m: "\n\n!bc %scod%s%s\n!ec\n" % (extended_markdown_language2dolang[m.group(1)], bc_postfix, unindent_lines(m.group(2).rstrip(), trailing_newline=False)), re.DOTALL), # language given
@@ -403,7 +412,7 @@ def markdown2doconce(filestr, format=None, ipynb_mode=False):
                         lines[i] = '  *' + lines[i][1:]
                     elif re.search(r'^\d+\. ', lines[i]):
                         lines[i] = re.sub(r'^\d+\. ', '  o ', lines[i])
-                except Exception, e:
+                except Exception as e:
                     raise e
         new_quote = '\n'.join(lines)
         # Cannot use re.sub since there are many strange chars (for regex)
@@ -812,7 +821,7 @@ def syntax_check(filestr, format):
     pattern = r'^[^#](---\s\w|\w\s---)'
     m = re.search(pattern, filestr, flags=re.MULTILINE)
     if m:
-        print '*** error: mdash (---) cannot have spaces around it'
+        print('*** error: mdash (---) cannot have spaces around it')
         errwarn(filestr[m.start()-20:m.start()+20])
         _abort()
 
@@ -828,7 +837,7 @@ def syntax_check(filestr, format):
     found_problem = False
     for eq_label in eq_labels:
         m_ = [re.search(pattern % eq_label, filestr) for pattern in
-              pattern1, pattern2, pattern3]
+              (pattern1, pattern2, pattern3)]
         for m in m_:
             if m:
                 errwarn('*** error: reference to equation label "%s" is without parentheses' % eq_label)
@@ -875,7 +884,7 @@ Causes of missing labels:
 
     # Quotes or inline verbatim is not allowed inside emphasize and bold:
     # (force non-blank in the beginning and end to avoid interfering with lists)
-    from common import inline_tag_begin, inline_tag_end
+    from .common import inline_tag_begin, inline_tag_end
     pattern = r'%s\*(?P<subst>[^ ][^*]+?[^ ])\*%s' % (inline_tag_begin, inline_tag_end)
     for dummy1, dummy2, phrase, dummy3, dummy4 in \
             re.findall(pattern, filestr, flags=re.MULTILINE):
@@ -1286,12 +1295,12 @@ def insert_code_from_file(filestr, format):
 
             try:
                 if 'http' in filename:
-                    import urllib
-                    codefile = urllib.urlopen(filename)
+                    import urllib.request, urllib.parse, urllib.error
+                    codefile = urllib.request.urlopen(filename)
                     errwarn('... fetching source code from ' + path_prefix)
                 else:
                     codefile = open(filename, 'r')
-            except IOError, e:
+            except IOError as e:
                 errwarn('*** error: could not open the file %s used in\n%s' % (filename, line))
                 if CREATE_DUMMY_FILE and 'No such file or directory' in str(e):
                     errwarn('    No such file or directory!')
@@ -1385,8 +1394,7 @@ def insert_code_from_file(filestr, format):
                 try:
                     from_, to_ = patterns.split('@')
                 except:
-                    raise SyntaxError, \
-                    'Syntax error: missing @ in regex in line\n  %s' % line
+                    raise SyntaxError('Syntax error: missing @ in regex in line\n  %s' % line)
 
                 errwarn('copying %s regex "%s" until %s\n     file: %s,' %
                         ('after' if fromto == 'from-to:' else 'from',
@@ -1459,7 +1467,7 @@ def insert_code_from_file(filestr, format):
                         errwarn('error: could not find regex "%s"!' % to_)
                     if from_found and to_found:
                         errwarn('"From" and "to" regex match at the same line - empty text.')
-                    print
+                    print()
                     _abort()
                 errwarn(' lines %d-%d' % (from_line, to_line), newline=False)
             codefile.close()
@@ -1563,7 +1571,7 @@ def exercises(filestr, format, code_blocks, tex_blocks):
     # __Hint 1.__ some paragraph...,
     # __Hint 2.__ ...
 
-    from common import _CODE_BLOCK, _MATH_BLOCK
+    from .common import _CODE_BLOCK, _MATH_BLOCK
 
     all_exer = []   # collection of all exercises
     exer = {}       # data for one exercise, to be appended to all_exer
@@ -1875,13 +1883,13 @@ def exercises(filestr, format, code_blocks, tex_blocks):
         filestr = '\n'.join(newlines)
         solutions = '\n'.join(solutions)
     except UnicodeDecodeError:
-        print '****** DOES THIS OCCUR AT ALL??? ******'
+        print('****** DOES THIS OCCUR AT ALL??? ******')
         filestr = '\n'.join([n.decode('utf-8') for n in newlines if isinstance(n, str)])
         solutions = '\n'.join([n.decode('utf-8') for n in solutions if isinstance(n, str)])
 
 
     if option('without_solutions') and option('solutions_at_end'):
-        from common import chapter_pattern
+        from .common import chapter_pattern
         if re.search(chapter_pattern, filestr, flags=re.MULTILINE):
             has_chapters = True
         else:
@@ -2291,7 +2299,7 @@ def typeset_tables(filestr, format):
     The list is easily translated to various output formats
     by other modules.
     """
-    from StringIO import StringIO
+    from io import StringIO
     result = StringIO()
 
     # Fix: make sure there is a blank line after the table
@@ -2623,7 +2631,7 @@ def typeset_lists(filestr, format, debug_info=[]):
     """
     debugpr('*** List typesetting phase + comments and blank lines ***')
     import string
-    from StringIO import StringIO
+    from io import StringIO
     result = StringIO()
     lastindent = 0
     lists = []
@@ -3111,7 +3119,7 @@ def handle_cross_referencing(filestr, format, tex_blocks):
 
     # 3. Replace ref by hardcoded numbers from a latex .aux file
     refaux = 'refaux{' in filestr
-    from latex import aux_label2number
+    from .latex import aux_label2number
     label2number = aux_label2number()
     if format not in ('latex', 'pdflatex') and refaux and not label2number:
         errwarn('*** error: used refaux{} reference(s), but no option --replace_ref_by_latex_auxno=')
@@ -3468,7 +3476,7 @@ def interpret_authors(filestr, format):
         # Avoid multiple versions of the same institution in copyright_
         #keys = list(set(list(copyright_.keys()))) # does not preserve seq.
         keys = []
-        for key in copyright_.keys():
+        for key in list(copyright_.keys()):
             if not key in keys:
                 keys.append(key)
         copy_copyright_ = copyright_.copy()
@@ -3538,7 +3546,7 @@ def typeset_authors(filestr, format):
 def typeset_section_numbering(filestr, format):
     chapter = section = subsection = subsubsection = 0
     # Do we have chapters?
-    from common import chapter_pattern
+    from .common import chapter_pattern
     if re.search(chapter_pattern, filestr, flags=re.MULTILINE):
         has_chapters = True
     else:
@@ -3941,7 +3949,7 @@ def inline_tag_subst(filestr, format):
             try:
                 locale.setlocale(locale.LC_TIME,
                                  locale_dict[locale_dict['language']]['locale'])
-            except locale.Error, e:
+            except locale.Error as e:
                 errwarn('*** error: ' + str(e))
                 errwarn('    locale=%s must be installed' % (locale_dict[locale_dict['language']]['locale']))
                 errwarn('    sudo locale-gen de_DE.UTF-8; sudo update-locale')
@@ -3950,7 +3958,7 @@ def inline_tag_subst(filestr, format):
 
         # Add copyright right under the date if present
         if format not in ('html', 'latex', 'pdflatex', 'sphinx'):
-            from common import get_copyfile_info
+            from .common import get_copyfile_info
             cr_text = get_copyfile_info(filestr, format=format)
             if cr_text is not None:
                 if cr_text == 'Made with DocOnce':
@@ -4069,7 +4077,7 @@ def inline_tag_subst(filestr, format):
                 if m:
                     try:
                         replacement_str = replacement(m)
-                    except Exception, e:
+                    except Exception as e:
                         errwarn('Problem at line\n   ' +  lines[i] +
                                 '\nException:\n' + str(e))
                         errwarn('occured while replacing inline tag "%s" (%s) with aid of function %s' % (tag, tag_pattern, replacement.__name__))
@@ -4082,7 +4090,7 @@ def inline_tag_subst(filestr, format):
             filestr = '\n'.join(lines)
 
         else:
-            raise ValueError, 'replacement is of type %s' % type(replacement)
+            raise ValueError('replacement is of type %s' % type(replacement))
 
         if occurences > 0:
             debugpr('\n**** The file after %d "%s" substitutions ***\n%s\n%s\n\n' % (occurences, tag, filestr, '-'*80))
@@ -4174,7 +4182,7 @@ def file2file(in_filename, format, basename):
 
     try:
         f.write(filestr)
-    except UnicodeEncodeError, e:
+    except UnicodeEncodeError as e:
         # Provide error message and abortion, because the code
         # below that tries UTF-8 will result in strange characters
         # in the output. It is better that the user specifies
@@ -4322,7 +4330,7 @@ def doconce2format(filestr, format):
     global locale_dict
     locale_dict['language'] = option('language=', 'English')
     if locale_dict['language'] not in locale_dict:
-        print '*** error: language "%s" not supported in locale_dict' % locale_dict['language']
+        print('*** error: language "%s" not supported in locale_dict' % locale_dict['language'])
         _abort()
     else:
         if locale_dict['language'] != 'English':
@@ -4413,7 +4421,7 @@ def doconce2format(filestr, format):
     m = re.search('^IBPLOT: *\[', filestr, flags=re.MULTILINE)
     has_ibplot = True if m else False
     if has_ibplot:
-        from html import embed_IBPLOTs
+        from .html import embed_IBPLOTs
         filestr, bg_session = embed_IBPLOTs(filestr, format)
         #bg_session.loop_until_closed()
         debugpr('The file after inserting interactive IBPLOT curve plots:', filestr)
@@ -4455,7 +4463,7 @@ def doconce2format(filestr, format):
 
     # Next step: substitute latex-style newcommands in filestr and tex_blocks
     # (not in code_blocks)
-    from expand_newcommands import expand_newcommands
+    from .expand_newcommands import expand_newcommands
     if format not in ('latex', 'pdflatex'):
         newcommand_files = glob.glob('newcommands*_replace.tex')
         if format in ('sphinx', 'pandoc', 'ipynb'):
@@ -5013,7 +5021,7 @@ The above code block contains "%s" on the *beginning of a line*.
 Such lines cause problems for the mako preprocessor
 since it thinks this is a mako statement.
 ''' % (m.group(0)))
-                    print
+                    print()
                     mako_problems = True
         if mako_problems:
             errwarn('''\
@@ -5065,7 +5073,7 @@ fix the lines as described or remove the mako statements.
                     '\n'.join(variables))
             m = re.search(pattern, filestr)
             if m:
-                print '    first occurrence:\n', filestr[m.start()-10:m.start()+20]
+                print('    first occurrence:\n', filestr[m.start()-10:m.start()+20])
             _abort()
 
         if preprocessor is not None:  # already found preprocess commands?
@@ -5111,7 +5119,7 @@ On Debian (incl. Ubuntu) systems, you can alternatively do
         #                strict_undefined=strict_undefined)
         if encoding:
             try:
-                filestr = unicode(filestr, encoding)
+                filestr = str(filestr, encoding)
             except UnicodeDecodeError as e:
                 if "unicode codec can't decode" in str(e):
                     errwarn(e)
@@ -5218,30 +5226,30 @@ def format_driver():
     global _log, encoding, filename, dofile_basename
 
     if '--options' in sys.argv:
-        from misc import help_format
+        from .misc import help_format
         help_format()
         sys.exit(1)
 
-    from misc import check_command_line_options
+    from .misc import check_command_line_options
     check_command_line_options(4)
 
     try:
         format = sys.argv[1]
         filename = sys.argv[2]
         del sys.argv[1:3]
-        import common
+        from . import common
         common.format = format
     except IndexError:
-        from misc import get_legal_command_line_options
+        from .misc import get_legal_command_line_options
         options = ' '.join(get_legal_command_line_options())
-        print 'Usage: %s format filename [preprocessor options] [%s]\n' \
-                % (sys.argv[0], options)
-        print 'Run "doconce format --options" to see explanation of all options'
+        print('Usage: %s format filename [preprocessor options] [%s]\n' \
+                % (sys.argv[0], options))
+        print('Run "doconce format --options" to see explanation of all options')
         if len(sys.argv) == 1:
-            print 'Missing format specification!'
-        print 'formats:', ', '.join(supported_format_names())
-        print '\n-DFORMAT=format is always defined when running preprocess'
-        print 'Other -Dvar or -Dvar=value options can be added'
+            print('Missing format specification!')
+        print('formats:', ', '.join(supported_format_names()))
+        print('\n-DFORMAT=format is always defined when running preprocess')
+        print('Other -Dvar or -Dvar=value options can be added')
         sys.exit(1)
 
     # Treat some synonyms of format
@@ -5250,7 +5258,7 @@ def format_driver():
 
     names = supported_format_names()
     if format not in names:
-        print '%s is not among the supported formats:\n%s' % (format, names)
+        print('%s is not among the supported formats:\n%s' % (format, names))
         _abort()
 
     encoding = option('encoding=', default='')
@@ -5265,7 +5273,7 @@ def format_driver():
     this file is not produced.
 
     """)
-        print '*** debug output in ' + _log_filename
+        print('*** debug output in ' + _log_filename)
 
 
     debugpr('\n\n******* output format: %s *******\n\n' % format)
@@ -5285,13 +5293,13 @@ def format_driver():
                 found = True
                 break
         if not found:
-            print '*** error: given doconce file "%s", but no' % basename
-            print '    files with extensions %s exist' % ' or '.join(legal_extensions)
+            print('*** error: given doconce file "%s", but no' % basename)
+            print('    files with extensions %s exist' % ' or '.join(legal_extensions))
             _abort()
     else:
         # Given extension
         if not os.path.isfile(filename):
-            print '*** error: file %s does not exist' % filename
+            print('*** error: file %s does not exist' % filename)
             _abort()
         if ext == '.txt':
             if filename.endswith('.do.txt'):
@@ -5301,8 +5309,8 @@ def format_driver():
         elif ext == '.do':
             basename = filename[:-3]
         else:
-            print '*** error: illegal file extension %s' % ext
-            print '    must be %s' % ' or '.join(legal_extensions)
+            print('*** error: illegal file extension %s' % ext)
+            print('    must be %s' % ' or '.join(legal_extensions))
             _abort()
 
     dofile_basename = basename  # global variable

--- a/lib/doconce/doconce.py
+++ b/lib/doconce/doconce.py
@@ -140,8 +140,6 @@ def debugpr(heading='', text=''):
     if option('debug'):
         global _log
         if encoding:
-            if sys.version_info[0] == 2 and isinstance(text, str):
-                text = text.decode(encoding)
             _log = codecs.open('_doconce_debugging.log','a', encoding)
         else:
             _log = open('_doconce_debugging.log','a')
@@ -165,8 +163,6 @@ def errwarn(msg, newline=True):
     logfilename = dofile_basename + '.dlog'
     mode = 'a' if os.path.isfile(logfilename) else 'w'
     if encoding:
-        if sys.version_info[0] == 2 and isinstance(msg, str):
-            msg = msg.decode(encoding)
         err = codecs.open(logfilename, mode, encoding)
     else:
         err = open(logfilename, mode)
@@ -1473,11 +1469,7 @@ def insert_code_from_file(filestr, format):
                 errwarn(' lines %d-%d' % (from_line, to_line), newline=False)
             codefile.close()
 
-            # Need a fix if utf-8 code in file
-            try:
-                "!bc %spro\n%s\n!ec" % (filetype, code)
-            except UnicodeDecodeError as e:
-                code = code.decode('utf-8')
+            "!bc %spro\n%s\n!ec" % (filetype, code)
 
             if code_envir in ('None', 'off', 'none'):
                 # no need to embed code in anything
@@ -1885,8 +1877,8 @@ def exercises(filestr, format, code_blocks, tex_blocks):
         solutions = '\n'.join(solutions)
     except UnicodeDecodeError:
         print('****** DOES THIS OCCUR AT ALL??? ******')
-        filestr = '\n'.join([n.decode('utf-8') for n in newlines if isinstance(n, basestring)])
-        solutions = '\n'.join([n.decode('utf-8') for n in solutions if isinstance(n, basestring)])
+        filestr = '\n'.join([n for n in newlines if isinstance(n, basestring)])
+        solutions = '\n'.join([n for n in solutions if isinstance(n, basestring)])
 
 
     if option('without_solutions') and option('solutions_at_end'):
@@ -3976,7 +3968,7 @@ def inline_tag_subst(filestr, format):
         try:
             filestr = filestr.replace(origstr, 'DATE: ' + date)
         except UnicodeDecodeError:
-            filestr = filestr.replace(origstr, 'DATE: ' + date.decode('utf-8'))
+            filestr = filestr.replace(origstr, 'DATE: ' + date)
 
     # Hack for not typesetting ampersands inside inline verbatim text
     groups = re.findall(INLINE_TAGS['verbatim'], filestr, flags=re.MULTILINE)

--- a/lib/doconce/epytext.py
+++ b/lib/doconce/epytext.py
@@ -1,5 +1,6 @@
+from __future__ import absolute_import
 import re
-from common import indent_lines, default_movie, plain_exercise
+from .common import indent_lines, default_movie, plain_exercise
 
 
 def epytext_author(authors_and_institutions, auth2index,
@@ -67,10 +68,10 @@ def define(FILENAME_EXTENSION,
         'ampersand2':    r' \g<1>&\g<2>',
         }
 
-    from rst import rst_code, rst_table
+    from .rst import rst_code, rst_table
     CODE['epytext'] = rst_code
     TABLE['epytext'] = rst_table
-    from plaintext import plain_ref_and_label, plain_index_bib
+    from .plaintext import plain_ref_and_label, plain_index_bib
     CROSS_REFS['epytext'] = plain_ref_and_label
     INDEX_BIB['epytext'] = plain_index_bib
     EXERCISE['epytext'] = plain_exercise
@@ -96,7 +97,7 @@ def define(FILENAME_EXTENSION,
         'module variable': '@var',
         }
     TOC['epytext'] = lambda x, f: '\n'  # no toc for epydoc
-    from plaintext import plain_quiz
+    from .plaintext import plain_quiz
     QUIZ['epytext'] = plain_quiz
 
     #insert QUIZ in various .py files, plaintext can do something simple, problem: cannot insert headline and exercise because then the exercise is not interpreted! problem2: quiz will just be a part of an exercises, unrendered

--- a/lib/doconce/expand_newcommands.py
+++ b/lib/doconce/expand_newcommands.py
@@ -1,14 +1,13 @@
+#!/usr/bin/env python
 from __future__ import print_function
 from __future__ import absolute_import
 from builtins import range
 from past.builtins import basestring
-#!/usr/bin/env python
+import shutil, re, sys, os
 
 # NOTE: all newcommands can only span *one line*!
 # (necessary requirement since a findall with re.DOTALL will
 # not catch the final } of a command, real parsing is then neeeded)
-
-import shutil, re, sys, os
 
 def process_newcommand(line):
     line = line.replace('renewcommand', 'newcommand') # make syntax uniform

--- a/lib/doconce/expand_newcommands.py
+++ b/lib/doconce/expand_newcommands.py
@@ -1,3 +1,7 @@
+from __future__ import print_function
+from __future__ import absolute_import
+from builtins import range
+from past.builtins import basestring
 #!/usr/bin/env python
 
 # NOTE: all newcommands can only span *one line*!
@@ -47,7 +51,7 @@ def process_newcommand(line):
 
     if found:
         # fix \x, \b, \r... etc in strings
-        from latex import fix_latex_command_regex as fix
+        from .latex import fix_latex_command_regex as fix
         pattern = fix(pattern, 'match')
         replacement = fix(replacement, 'replacement')
         return pattern, replacement
@@ -88,7 +92,7 @@ def substitute(source, newcommands):
     else:
         text = source
 
-    from doconce import debugpr
+    from .doconce import debugpr
     for pattern, replacement in newcommands:
         text, n = re.subn(pattern, replacement, text)
         if n:
@@ -124,9 +128,9 @@ def expand_newcommands(newcommands_files, source):
 
 if __name__ == '__main__':
     if len(sys.argv) < 3:
-        print 'Usage: expand_newcommands.py newcommands_file source_file1 source_file2 ...'
+        print('Usage: expand_newcommands.py newcommands_file source_file1 source_file2 ...')
         sys.exit(1)
     newcommands_file = sys.argv[1]
     for source_file in sys.argv[2:]:
-        print 'expanding newcommands in', source_file
+        print('expanding newcommands in', source_file)
         expand_newcommands(newcommands_file, source_file)

--- a/lib/doconce/gwiki.py
+++ b/lib/doconce/gwiki.py
@@ -3,14 +3,18 @@ Google Code Wiki translator.
 Syntax defined by http://code.google.com/p/support/wiki/WikiSyntax
 Here called gwiki to make the dialect clear (g for google).
 """
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import zip
 
 
-import re, os, commands, sys
-from common import default_movie, plain_exercise, insert_code_and_tex, \
+import re, os, subprocess, sys
+from .common import default_movie, plain_exercise, insert_code_and_tex, \
      fix_ref_section_chapter
-from plaintext import plain_quiz
-from misc import _abort
-from doconce import errwarn
+from .plaintext import plain_quiz
+from .misc import _abort
+from .doconce import errwarn
 
 def gwiki_code(filestr, code_blocks, code_block_types,
                tex_blocks, format):
@@ -38,7 +42,7 @@ def gwiki_figure(m):
             # try to convert image file to PNG, using
             # convert from ImageMagick:
             cmd = 'convert %s png:%s' % (filename, root+'.png')
-            failure, output = commands.getstatusoutput(cmd)
+            failure, output = subprocess.getstatusoutput(cmd)
             if failure:
                 errwarn('\n**** Warning: could not run ' + cmd)
                 errwarn('Convert %s to PNG format manually' % filename)
@@ -72,7 +76,7 @@ googlecode repository) and substitute the line above with the URL.
 """ % (caption, filename, filename)
     return result
 
-from common import table_analysis
+from .common import table_analysis
 
 def gwiki_table(table):
     """Native gwiki table."""
@@ -154,7 +158,7 @@ def wiki_ref_and_label_common(section_label2title, format, filestr):
         filestr = filestr.replace('ref{%s}' % label,
                                   '[#%s]' % title.replace(' ', '_'))
 
-    from common import ref2equations
+    from .common import ref2equations
     filestr = ref2equations(filestr)
 
     # replace remaining ref{x} as x
@@ -225,7 +229,7 @@ def define(FILENAME_EXTENSION,
         }
 
     CODE['gwiki'] = gwiki_code
-    from html import html_table
+    from .html import html_table
     #TABLE['gwiki'] = html_table
     TABLE['gwiki'] = gwiki_table
 
@@ -255,7 +259,7 @@ def define(FILENAME_EXTENSION,
         'search': ('.png', '.gif', '.jpg', '.jpeg'),
         'convert': ('.png', '.gif', '.jpg')}
     CROSS_REFS['gwiki'] = gwiki_ref_and_label
-    from plaintext import plain_index_bib
+    from .plaintext import plain_index_bib
     EXERCISE['gwiki'] = plain_exercise
     INDEX_BIB['gwiki'] = plain_index_bib
     TOC['gwiki'] = lambda s, f: '<wiki: toc max_depth="2" />'

--- a/lib/doconce/html.py
+++ b/lib/doconce/html.py
@@ -49,7 +49,7 @@ def add_to_file_collection(filename, doconce_docname=None, mode='a'):
     and this name is used to set the filename of the file collection.
     Later, `doconce_docname` is not given (otherwise previous info is erased).
     """
-    if isinstance(filename, str):
+    if isinstance(filename, basestring):
         filenames = [filename]
     elif isinstance(filename, (list,tuple)):
         filenames = filename
@@ -2347,7 +2347,7 @@ def html_index_bib(filestr, index, citations, pubfile, pubdata):
             except UnicodeDecodeError as e:
                 if "can't decode byte" in str(e):
                     try:
-                        bibtext = bibtext.decode('utf-8').replace(
+                        bibtext = bibtext.replace(
                             'label{%s}' % label, '<a name="%s"></a>' % label)
                     except UnicodeDecodeError as e:
                         errwarn('UnicodeDecodeError: ' + e)
@@ -3352,7 +3352,7 @@ def latin2html(text):
     # codes and writing them out in html
     text_new = []
     try:
-        text = text.decode('utf-8')
+        text = text
     except UnicodeDecodeError as e:
         try:
             text = text.decode('latin-1')

--- a/lib/doconce/html.py
+++ b/lib/doconce/html.py
@@ -1528,9 +1528,9 @@ function show_hide_code%d(){
                                           contents)
             except UnicodeDecodeError:
                 filestr = filestr.replace('***TABLE_OF_CONTENTS***',
-                                          toc_html.decode('utf-8'))
+                                          toc_html)
                 filestr = filestr.replace('***CONTENTS_PULL_DOWN_MENU***',
-                                          contents.decode('utf-8'))
+                                          contents)
 
         jumbotron = option('html_bootstrap_jumbotron=', 'on')
         if jumbotron != 'off':
@@ -3348,19 +3348,7 @@ def latin2html(text):
     if not isinstance(text, str):
         return text
 
-    # Turn ascii into utf-8 or latin-1 before finding the ord(c)
-    # codes and writing them out in html
     text_new = []
-    try:
-        text = text
-    except UnicodeDecodeError as e:
-        try:
-            text = text.decode('latin-1')
-        except UnicodeDecodeError as e:
-            errwarn('Tried to interpret the file as utf-8 (failed) and latin-1 (failed) - aborted')
-            raise e
-    #except UnicodeEncodeError, e:
-    #    pass
     for c in text:
         try:
             if ord(c) > 159:

--- a/lib/doconce/html.py
+++ b/lib/doconce/html.py
@@ -1,11 +1,18 @@
+from __future__ import print_function
+from __future__ import absolute_import
+from builtins import zip
+from builtins import str
+from builtins import range
+from past.builtins import basestring
+from builtins import object
 import re, os, glob, sys, glob
-from common import table_analysis, plain_exercise, insert_code_and_tex, \
+from .common import table_analysis, plain_exercise, insert_code_and_tex, \
      indent_lines, online_python_tutor, bibliography, \
      is_file_or_url, envir_delimiter_lines, doconce_exercise_output, \
      get_legal_pygments_lexers, has_custom_pygments_lexer, emoji_url, \
      fix_ref_section_chapter
-from misc import option, _abort
-from doconce import errwarn, locale_dict
+from .misc import option, _abort
+from .doconce import errwarn, locale_dict
 
 box_shadow = 'box-shadow: 8px 8px 5px #888888;'
 #box_shadow = 'box-shadow: 0px 0px 10px #888888'
@@ -42,7 +49,7 @@ def add_to_file_collection(filename, doconce_docname=None, mode='a'):
     and this name is used to set the filename of the file collection.
     Later, `doconce_docname` is not given (otherwise previous info is erased).
     """
-    if isinstance(filename, (str,unicode)):
+    if isinstance(filename, str):
         filenames = [filename]
     elif isinstance(filename, (list,tuple)):
         filenames = filename
@@ -657,7 +664,7 @@ def toc2html(html_style, bootstrap=True,
         _abort()
     return toc_html
 
-class CreateApp():
+class CreateApp(object):
     """
     Class for interactive Bokeh plots.
     Written by Fredrik Eikeland Fossan <fredrik.e.fossan@ntnu.no>.
@@ -712,7 +719,7 @@ class CreateApp():
         self.x = linspace(xrange[0], xrange[1], N)
         self.reverseAxes = reverseAxes
         if sliderDict != None:
-            self.parameters = sliderDict.keys()
+            self.parameters = list(sliderDict.keys())
 
             for n, param in enumerate(self.parameters):
                 exec("sliderInstance = Slider(" + sliderDict[param] + ")") # Todo: Fix so exec is not needed
@@ -870,7 +877,7 @@ def embed_IBPLOTs(filestr, format):
     return filestr, session
 
 def embed_newcommands(filestr):
-    from expand_newcommands import process_newcommand
+    from .expand_newcommands import process_newcommand
     newcommands_files = list(
         sorted([name
                 for name in glob.glob('newcommands*.tex')
@@ -1150,7 +1157,7 @@ function show_hide_code%d(){
             tex_blocks[i] = re.sub(r'<([^ {}])', '< \g<1>', tex_blocks[i])
             errwarn('    changed to')
             errwarn(tex_blocks[i])
-            print
+            print()
 
     if option('wordpress'):
         # Change all equations to $latex ...$\n
@@ -1240,7 +1247,7 @@ function show_hide_code%d(){
             tex_blocks[i] = re.sub(r'^label\{', '\\label{', tex_blocks[i],
                                    flags=re.MULTILINE)
 
-    from doconce import debugpr
+    from .doconce import debugpr
     debugpr('File before call to insert_code_and_tex (format html):', filestr)
     filestr = insert_code_and_tex(filestr, code_blocks, tex_blocks, format)
     debugpr('File after call to insert_code_and tex (format html):', filestr)
@@ -1329,7 +1336,7 @@ function show_hide_code%d(){
             filestr = latex + filestr
 
     # Copyright
-    from common import get_copyfile_info
+    from .common import get_copyfile_info
     cr_text = get_copyfile_info(filestr, format=format)
     if cr_text is not None:
         filestr = filestr.replace('Copyright COPYRIGHT_HOLDERS',
@@ -1362,7 +1369,7 @@ function show_hide_code%d(){
                          filestr, flags=re.DOTALL)
 
     # Find all URLs to files (non http, ftp)
-    import common
+    from . import common
     pattern = '<a href=' + common._linked_files
     files = re.findall(pattern, filestr)
     for f, dummy in files:
@@ -1409,7 +1416,7 @@ function show_hide_code%d(){
     # toc_html lacks formatting, run some basic formatting here
     tags = 'emphasize', 'bold', 'math', 'verbatim', 'colortext'
     # drop URLs in headings?
-    import common
+    from . import common
     for tag in tags:
         toc_html = re.sub(common.INLINE_TAGS[tag],
                           common.INLINE_TAGS_SUBST[format][tag],
@@ -1469,7 +1476,7 @@ function show_hide_code%d(){
         # Check that template does not have "main content" begin and
         # end lines that may interfere with the automatically generated
         # ones in DocOnce (may destroy the split_html command)
-        from doconce import main_content_char as _c
+        from .doconce import main_content_char as _c
         m = re.findall(r'(<!-- %s+ main content %s+)' % (_c,_c), template)
         if m:
             errwarn('*** error: template contains lines that may interfere')
@@ -1984,7 +1991,7 @@ def html_movie(m):
         # frame_*.png
         # frame_%04d.png:0->120
         # http://some.net/files/frame_%04d.png:0->120
-        import DocWriter
+        from . import DocWriter
         try:
             header, jscode, form, footer, frames = \
                     DocWriter.html_movie(filename, **kwargs)
@@ -2256,7 +2263,7 @@ def html_ref_and_label(section_label2title, format, filestr):
 
     filestr = '\n'.join(lines)
 
-    for label, no in label2no.iteritems():
+    for label, no in label2no.items():
         filestr = filestr.replace('ref{%s}' % label,
                                   '<a href="#%s">%s</a>' % (label, str(no)))
         # we allow 'non-number numbers' for custom environments like 'theorem A'
@@ -2324,7 +2331,7 @@ def html_exercise(exer):
 
 def html_index_bib(filestr, index, citations, pubfile, pubdata):
     if citations:
-        from common import cite_with_multiple_args2multiple_cites
+        from .common import cite_with_multiple_args2multiple_cites
         filestr = cite_with_multiple_args2multiple_cites(filestr)
     for label in citations:
         filestr = filestr.replace('cite{%s}' % label,
@@ -2337,12 +2344,12 @@ def html_index_bib(filestr, index, citations, pubfile, pubdata):
                 bibtext = bibtext.replace(
                     'label{%s}' % label, '<a name="%s"></a>' % label)
                 # (<a name=""></a> is later replaced by a div tag)
-            except UnicodeDecodeError, e:
+            except UnicodeDecodeError as e:
                 if "can't decode byte" in str(e):
                     try:
                         bibtext = bibtext.decode('utf-8').replace(
                             'label{%s}' % label, '<a name="%s"></a>' % label)
-                    except UnicodeDecodeError, e:
+                    except UnicodeDecodeError as e:
                         errwarn('UnicodeDecodeError: ' + e)
                         errwarn('*** error: problems in %s' % pubfile)
                         errwarn('    with key ' + label)
@@ -3156,7 +3163,7 @@ body { %s; }
             # Make link back to the main HTML file
             outfilename = option('html_output=', None)
             if outfilename is None:
-                from doconce import dofile_basename
+                from .doconce import dofile_basename
                 outfilename = dofile_basename + '.html'
             else:
                 if not outfilename.endswith('html'):
@@ -3214,7 +3221,7 @@ body { %s; }
     keywords = [keyword for keyword in keywords
                 if not '`' in keyword]
     # Keywords paragraph
-    import common
+    from . import common
     m = re.search(common.INLINE_TAGS['keywords'], filestr, flags=re.MULTILINE)
     if m:
         keywords += re.split(r', *', m.group(1))
@@ -3301,7 +3308,7 @@ Automatically generated HTML file from DocOnce source
 <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.js"></script>
 """
 
-    from common import has_copyright
+    from .common import has_copyright
     copyright_, symbol = has_copyright(filestr)
     if copyright_:
         OUTRO['html'] += """
@@ -3346,10 +3353,10 @@ def latin2html(text):
     text_new = []
     try:
         text = text.decode('utf-8')
-    except UnicodeDecodeError, e:
+    except UnicodeDecodeError as e:
         try:
             text = text.decode('latin-1')
-        except UnicodeDecodeError, e:
+        except UnicodeDecodeError as e:
             errwarn('Tried to interpret the file as utf-8 (failed) and latin-1 (failed) - aborted')
             raise e
     #except UnicodeEncodeError, e:
@@ -3360,7 +3367,7 @@ def latin2html(text):
                 text_new.append('&#%d;' % ord(c))
             else:
                 text_new.append(c)
-        except Exception, e:
+        except Exception as e:
             errwarn(e)
             errwarn('character causing problems: ' + c)
             raise e.__class__('%s: character causing problems: %s' % \

--- a/lib/doconce/ipynb.py
+++ b/lib/doconce/ipynb.py
@@ -330,9 +330,9 @@ def ipynb_code(filestr, code_blocks, code_block_types,
     # Only typeset Python code as blocks, otherwise !bc environmens
     # become plain indented Markdown.
     from .doconce import dofile_basename
-    from sets import Set
+    
     ipynb_tarfile = 'ipynb-%s-src.tar.gz' % dofile_basename
-    src_paths = Set()
+    src_paths = set()
     mpl_inline = False
 
     split_pyshell = option('ipynb_split_pyshell=', 'on')

--- a/lib/doconce/ipynb.py
+++ b/lib/doconce/ipynb.py
@@ -1,11 +1,14 @@
+from __future__ import absolute_import
+from builtins import str
+from builtins import range
 import re, sys, shutil, os
-from common import default_movie, plain_exercise, table_analysis, \
+from .common import default_movie, plain_exercise, table_analysis, \
      insert_code_and_tex, indent_lines
-from html import html_movie, html_table
-from pandoc import pandoc_ref_and_label, pandoc_index_bib, pandoc_quote, \
+from .html import html_movie, html_table
+from .pandoc import pandoc_ref_and_label, pandoc_index_bib, pandoc_quote, \
      language2pandoc, pandoc_quiz
-from misc import option, _abort
-from doconce import errwarn
+from .misc import option, _abort
+from .doconce import errwarn
 
 # Global variables
 figure_encountered = False
@@ -93,7 +96,7 @@ def ipynb_figure(m):
             #text += '<a name="%s"></a>' % label
             text += '<div id="%s"></div>\n' % label
         # Fix caption markup so it becomes html
-        from doconce import INLINE_TAGS_SUBST, INLINE_TAGS
+        from .doconce import INLINE_TAGS_SUBST, INLINE_TAGS
         for tag in 'bold', 'emphasize', 'verbatim':
             caption = re.sub(INLINE_TAGS[tag], INLINE_TAGS_SUBST['html'][tag],
                              caption, flags=re.MULTILINE)
@@ -243,7 +246,7 @@ def ipynb_code(filestr, code_blocks, code_block_types,
 
     # filestr becomes json list after this function so we must typeset
     # envirs here. All envirs are typeset as pandoc_quote.
-    from common import _CODE_BLOCK, _MATH_BLOCK
+    from .common import _CODE_BLOCK, _MATH_BLOCK
     envir_format = option('ipynb_admon=', 'paragraph')
     # Remove all !bpop-!epop environments (they cause only problens and
     # have no use)
@@ -255,7 +258,7 @@ def ipynb_code(filestr, code_blocks, code_block_types,
     filestr = re.sub('^<!-- !bnotes.*?<!-- !enotes -->\n', '', filestr,
                      flags=re.DOTALL|re.MULTILINE)
     filestr = re.sub('^<!-- !split -->\n', '', filestr, flags=re.MULTILINE)
-    from doconce import doconce_envirs
+    from .doconce import doconce_envirs
     envirs = doconce_envirs()[8:-2]
     for envir in envirs:
         pattern = r'^!b%s(.*?)\n(.+?)\s*^!e%s' % (envir, envir)
@@ -326,7 +329,7 @@ def ipynb_code(filestr, code_blocks, code_block_types,
     # Insert %matplotlib inline in the first block using matplotlib
     # Only typeset Python code as blocks, otherwise !bc environmens
     # become plain indented Markdown.
-    from doconce import dofile_basename
+    from .doconce import dofile_basename
     from sets import Set
     ipynb_tarfile = 'ipynb-%s-src.tar.gz' % dofile_basename
     src_paths = Set()
@@ -751,7 +754,7 @@ def ipynb_index_bib(filestr, index, citations, pubfile, pubdata):
     # Quite some code here is copy from latex_index_bib
     # http://nbviewer.ipython.org/github/ipython/nbconvert-examples/blob/master/citations/Tutorial.ipynb
     if citations:
-        from common import cite_with_multiple_args2multiple_cites
+        from .common import cite_with_multiple_args2multiple_cites
         filestr = cite_with_multiple_args2multiple_cites(filestr)
     for label in citations:
         filestr = filestr.replace('cite{%s}' % label,
@@ -773,7 +776,7 @@ def ipynb_index_bib(filestr, index, citations, pubfile, pubdata):
         os.chdir(this_dir)
 
         bibstyle = option('latex_bibstyle=', 'plain')
-        from latex import fix_latex_command_regex
+        from .latex import fix_latex_command_regex
         bibtext = fix_latex_command_regex(r"""
 ((*- extends 'latex_article.tplx' -*))
 
@@ -852,7 +855,7 @@ def define(FILENAME_EXTENSION,
     # treatment of envirs in ipynb_code and ENVIRS can be empty.
     ENVIRS['ipynb'] = {}
 
-    from common import DEFAULT_ARGLIST
+    from .common import DEFAULT_ARGLIST
     ARGLIST['ipynb'] = DEFAULT_ARGLIST
     LIST['ipynb'] = {
         'itemize':

--- a/lib/doconce/latex.py
+++ b/lib/doconce/latex.py
@@ -1,8 +1,8 @@
 # -*- coding: iso-8859-15 -*-
 
-from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import division
 from future import standard_library
 standard_library.install_aliases()
 from builtins import zip
@@ -1663,7 +1663,7 @@ def latex_title(m):
 %\contentsline{chapter}{Bibliography}{829}{chapter.Bib}
 %\contentsline{chapter}{Index}{831}{chapter.Index}
 """
-    text += """
+    text += r"""
 
 % ----------------- title -------------------------
 """
@@ -1762,7 +1762,7 @@ def latex_author(authors_and_institutions, auth2index,
         if len(auth2index[author]) == 1:
             one_author_at_one_institution = True
 
-    text = """
+    text = r"""
 
 % ----------------- author(s) -------------------------
 """
@@ -1917,7 +1917,7 @@ def latex_author(authors_and_institutions, auth2index,
         errwarn('    --latex_title_layout=%s --latex_style=%s' % (title_layout, latex_style))
         _abort()
 
-    text += """
+    text += r"""
 % ----------------- end author(s) -------------------------
 
 """
@@ -2056,8 +2056,9 @@ def latex_ref_and_label(section_label2title, format, filestr):
     filestr = re.sub(r'\s+ref\{', replacement, filestr)
     # It is very confusing with \vref{} to undefined labels, so
     # let's detect them and replace with ref
-    _label_pattern = r'\label\{(.+?)\}'
-    _ref_pattern = r'\v?ref\{(.+?)\}'
+    _label_pattern = r'\\label\{(.+?)\}'
+    _ref_pattern = r'\\v?ref\{(.+?)\}'
+    print("Final all", _label_pattern)
     labels = re.findall(_label_pattern, filestr)
     refs   = re.findall(_ref_pattern,   filestr)
     external_refs = []
@@ -3476,20 +3477,6 @@ justified,
 \usepackage{chngcntr}
 \counterwithin{doconcequizcounter}{chapter}
 """
-
-    '''
-    # Package for quiz
-    # http://ctan.uib.no/macros/latex/contrib/exam/examdoc.pdf
-    # Requires documentclass{exam} and cannot be used in combination
-    # with other documentclass
-    if '!bquiz' in filestr:
-        INTRO['latex'] += r"""
-\usepackage{exam}            % for quiz typesetting
-\newcommand{\questionlabel}{}
-\CorrectChoiceEmphasis{\itshape}
-\checkboxchar{$\Box$}\checkedchar{$\blacksquare$}
-"""
-    '''
 
     # Make sure hyperlinks are black (as the text) for printout
     # and otherwise set to the dark blue linkcolor

--- a/lib/doconce/latex.py
+++ b/lib/doconce/latex.py
@@ -1,12 +1,21 @@
 # -*- coding: iso-8859-15 -*-
 
-import os, commands, re, sys, glob, shutil, subprocess
-from common import plain_exercise, table_analysis, \
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import zip
+from builtins import str
+from builtins import range
+from past.utils import old_div
+import os, subprocess, re, sys, glob, shutil, subprocess
+from .common import plain_exercise, table_analysis, \
      _CODE_BLOCK, _MATH_BLOCK, doconce_exercise_output, indent_lines, \
      online_python_tutor, envir_delimiter_lines, safe_join, \
      insert_code_and_tex, is_file_or_url, chapter_pattern
-from misc import option, _abort, replace_code_command
-from doconce import errwarn, debugpr, locale_dict
+from .misc import option, _abort, replace_code_command
+from .doconce import errwarn, debugpr, locale_dict
 additional_packages = ''  # comma-sep. list of packages for \usepackage{}
 
 include_numbering_of_exercises = True
@@ -43,7 +52,7 @@ def aux_label2number():
 def get_bib_index_pages():
     """Find the page number for the Index and Bibliography from .aux file."""
     bib_page = idx_page = '9999'
-    from doconce import dofile_basename
+    from .doconce import dofile_basename
     name = dofile_basename + '.aux'
     if not os.path.isfile(name):
         return bib_page, idx_page
@@ -127,7 +136,7 @@ def latex_code_envir(
         envir_tp = 'cod'
         envir = envir[:-3]
 
-    from common import get_legal_pygments_lexers
+    from .common import get_legal_pygments_lexers
     global envir2pyg, envir2lst
 
     if envir in ('ipy', 'do'):
@@ -550,7 +559,7 @@ def latex_code(filestr, code_blocks, code_block_types,
                         code_block_types[_block_no] = new_envir
                     else:
                         if _envir not in admon_envir_mapping:
-                            print '*** error: requested %s to be replaced by something else inside admons, but\n    envir %s is not defined as part of --latex_admon_envir_map=...' % (_envir, _envir)
+                            print('*** error: requested %s to be replaced by something else inside admons, but\n    envir %s is not defined as part of --latex_admon_envir_map=...' % (_envir, _envir))
                             _abort()
                         new_envir = admon_envir_mapping[_envir]
                         lines[i] = lines[i].replace(_envir, new_envir)
@@ -580,7 +589,7 @@ def latex_code(filestr, code_blocks, code_block_types,
             new_envirs.append(envir + admon_envir_mapping['all'])
     envirs += new_envirs
     # Add all possible pygments envirs
-    from common import has_custom_pygments_lexer, get_legal_pygments_lexers
+    from .common import has_custom_pygments_lexer, get_legal_pygments_lexers
     if 'ipy' in code_block_types:
         has_custom_pygments_lexer('ipy')
     if 'do' in code_block_types:
@@ -656,7 +665,7 @@ def latex_code(filestr, code_blocks, code_block_types,
     pattern = r'(begin\{block\}|paragraph)\{.*?\\code\{.*?%.*?\}'
     filestr = re.sub(pattern, lambda m: m.group().replace('%', '\\%'), filestr)
 
-    from common import get_copyfile_info
+    from .common import get_copyfile_info
     cr_text = get_copyfile_info(filestr, format=format)
     if cr_text is not None:
         filestr = filestr.replace('Copyright COPYRIGHT_HOLDERS',
@@ -1079,8 +1088,8 @@ def latex_figure(m):
         if is_file_or_url(filename) != 'url':
             errwarn('*** error: cannot fetch latex figure %s on the net (no connection or invalid URL)' % filename)
             _abort()
-        import urllib
-        f = urllib.urlopen(filename)
+        import urllib.request, urllib.parse, urllib.error
+        f = urllib.request.urlopen(filename)
         file_content = f.read()
         f.close()
         f = open(basename, 'w')
@@ -1269,7 +1278,7 @@ def latex_movie(m):
 
     def link_to_local_html_movie_player():
         """Simple solution where an HTML file is made for playing the movie."""
-        from common import default_movie
+        from .common import default_movie
         text = default_movie(m)
 
         # URL to HTML viewer file must have absolute path in \href
@@ -1327,12 +1336,12 @@ modestbranding=1   %% no YouTube logo in control bar
             # make a separate html file that can play the animation
             text += link_to_local_html_movie_player()
         else:
-            import DocWriter
+            from . import DocWriter
             header, jscode, form, footer, frames = \
                     DocWriter.html_movie(filename)
             # Make a good estimate of the frame rate: it takes 30 secs
             # to run the animation: rate*30 = no of frames
-            framerate = int(len(frames)/30.)
+            framerate = int(old_div(len(frames),30.))
             commands = [r'\includegraphics[width=0.9\textwidth]{%s}' %
                         f for f in frames]
             commands = ('\n\\newframe\n').join(commands)
@@ -2273,7 +2282,7 @@ def _get_admon_figs(filename):
     if not os.path.isdir(latexfigdir_all):
         os.mkdir(latexfigdir_all)
         os.chdir(latexfigdir_all)
-        import doconce
+        from . import doconce
         doconce_dir = os.path.dirname(doconce.__file__)
         doconce_datafile = os.path.join(doconce_dir, datafile)
         #errwarn('copying admon figures from %s to subdirectory %s' % \)
@@ -2605,7 +2614,7 @@ def latex_quiz(quiz):
                 text += '$\bigcirc$ '
 
         text += '\n' + choice[1] + '\n\n'
-    from common import envir_delimiter_lines
+    from .common import envir_delimiter_lines
     if not option('without_answers'):
         begin, end = envir_delimiter_lines['ans']
         correct = [i for i, choice in enumerate(quiz['choices'])
@@ -2698,7 +2707,7 @@ def define(FILENAME_EXTENSION,
            OUTRO,
            filestr):
     # all arguments are dicts and accept in-place modifications (extensions)
-    from common import INLINE_TAGS
+    from .common import INLINE_TAGS
     m = re.search(INLINE_TAGS['inlinecomment'], filestr, flags=re.DOTALL)
     has_inline_comments = True if m else False
 
@@ -2939,7 +2948,7 @@ def define(FILENAME_EXTENSION,
 %-------------------- begin preamble ----------------------
 """
 
-    from misc import copy_latex_packages
+    from .misc import copy_latex_packages
 
     side_tp = 'twoside' if option('device=') == 'paper' else 'oneside'
     draft = 'draft' if option('draft') else 'final'
@@ -3616,7 +3625,7 @@ justified,
 %\doublespacing
 """
 
-    from common import has_copyright
+    from .common import has_copyright
     copyright_, symbol = has_copyright(filestr)
     symbol = r'\copyright\ ' if symbol else ''
     fancy_header = option('latex_fancy_header')

--- a/lib/doconce/matlabnb.py
+++ b/lib/doconce/matlabnb.py
@@ -13,12 +13,16 @@ does not work properly.
 
 2.
 """
+from __future__ import absolute_import
+from builtins import str
+from builtins import range
+from past.builtins import basestring
 import re, sys
-from common import default_movie, plain_exercise, bibliography, \
+from .common import default_movie, plain_exercise, bibliography, \
      cite_with_multiple_args2multiple_cites, insert_code_and_tex, \
      fix_ref_section_chapter
-from misc import option
-from doconce import errwarn
+from .misc import option
+from .doconce import errwarn
 
 def matlabnb_author(authors_and_institutions, auth2index,
                  inst2index, index2inst, auth2email):
@@ -62,7 +66,7 @@ def matlabnb_code(filestr, code_blocks, code_block_types,
                 if not (line.startswith('!bc') or line.startswith('!ec'))]) + '\n'
 
     # Insert % at the beginning of each line
-    from common import _CODE_BLOCK, _MATH_BLOCK
+    from .common import _CODE_BLOCK, _MATH_BLOCK
     code_line = r'^\d+ ' + _CODE_BLOCK
     code_line_problem = r' (\d+ ' + _CODE_BLOCK + ')'
     math_line = r'^\d+ ' + _MATH_BLOCK
@@ -128,7 +132,7 @@ def matlabnb_ref_and_label(section_label2title, format, filestr):
         filestr = filestr.replace('ref{%s}' % label,
                                   '"%s"' % section_label2title[label])
 
-    from common import ref2equations
+    from .common import ref2equations
     filestr = ref2equations(filestr)
 
     return filestr
@@ -314,7 +318,7 @@ def define(FILENAME_EXTENSION,
         }
 
     CODE['matlabnb'] = matlabnb_code
-    from common import DEFAULT_ARGLIST
+    from .common import DEFAULT_ARGLIST
     ARGLIST['matlabnb'] = DEFAULT_ARGLIST
     FIGURE_EXT['matlabnb'] = {
         'search': ('.png', '.gif', '.jpg', '.jpeg', '.pdf'),  #.pdf?
@@ -332,14 +336,14 @@ def define(FILENAME_EXTENSION,
         'separator': '\n',
         }
     CROSS_REFS['matlabnb'] = matlabnb_ref_and_label
-    from html import html_table
+    from .html import html_table
     TABLE['matlabnb'] = html_table
     #TABLE['matlabnb'] = matlabnb_table
     EXERCISE['matlabnb'] = plain_exercise
     INDEX_BIB['matlabnb'] = matlabnb_index_bib
     TOC['matlabnb'] = matlabnb_toc
 
-    from common import indent_lines
+    from .common import indent_lines
     ENVIRS['matlabnb'] = {
         'warning':   lambda block, format, title='Warning', text_size='normal':
            matlabnb_box(block, title),

--- a/lib/doconce/misc.py
+++ b/lib/doconce/misc.py
@@ -1,5 +1,17 @@
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+from past.builtins import execfile
+from future import standard_library
+from functools import reduce
+standard_library.install_aliases()
+from builtins import zip
+from builtins import str
+from builtins import range
+from past.builtins import basestring
+from past.utils import old_div
 import os, sys, shutil, re, glob, time, subprocess, codecs
-from doconce import errwarn
+from .doconce import errwarn
 
 _part_filename = '._%s%03d'
 _part_filename_wildcard = '._*[0-9][0-9][0-9]'
@@ -607,17 +619,17 @@ def get_legal_command_line_options():
     return _legal_command_line_options
 
 def help_format():
-    print """
+    print("""
 doconce format X doconcefile
 
 where X can be any of the formats
 html, latex, pdflatex, rst, sphinx, plain, gwiki, mwiki, cwiki,
 pandoc, epytext.
-"""
+""")
     for opt, help in _registered_command_line_options:
         if opt.endswith('='):
             opt += '...'
-        print '\n%s\n\n%s\n' % (opt, help)
+        print('\n%s\n\n%s\n' % (opt, help))
 
 # Import options from config file instead of the command line
 try:
@@ -625,7 +637,7 @@ try:
     # Above module must do from doconce.doconce_config_default import *
 except ImportError:
     # No doconce_config module, rely on this package's default
-    import doconce_config_default as doconce_config
+    from . import doconce_config_default as doconce_config
 
 # Challenge: want different doconce_config files: just
 # use different dirs and have one local in each
@@ -694,8 +706,8 @@ def check_command_line_options(option_start):
             arg = arg.split('=')[0] + '='
         if arg[:2] == '--':
             if not arg in _legal_command_line_options:
-                print '*** warning: unrecognized command-line option'
-                print '    ' + arg_user
+                print('*** warning: unrecognized command-line option')
+                print('    ' + arg_user)
 
 
 def misc_option(name, default=None):
@@ -720,7 +732,7 @@ def _abort():
     if '--no_abort' in sys.argv:
         errwarn('avoided abortion because of --no-abort')
     else:
-        print 'Abort! (add --no_abort on the command line to avoid this abortion)'
+        print('Abort! (add --no_abort on the command line to avoid this abortion)')
         sys.exit(1)
 
 def system(cmd, abort_on_failure=True, verbose=False, failure_info=''):
@@ -731,10 +743,10 @@ def system(cmd, abort_on_failure=True, verbose=False, failure_info=''):
     If verbose: print cmd.
     """
     if verbose or '--verbose' in sys.argv:
-        print 'running ' + cmd
+        print('running ' + cmd)
     failure = os.system(cmd)
     if failure:
-        print 'could not run ' + cmd + ' ' + failure_info
+        print('could not run ' + cmd + ' ' + failure_info)
         if abort_on_failure:
             _abort()
     return failure
@@ -859,33 +871,33 @@ def remove_inline_comments():
     try:
         filename = sys.argv[1]
     except IndexError:
-        print 'Usage: doconce remove_inline_comments myfile.do.txt'
+        print('Usage: doconce remove_inline_comments myfile.do.txt')
         _abort()
 
     if not os.path.isfile(filename):
-        print '*** error: file %s does not exist!' % filename
+        print('*** error: file %s does not exist!' % filename)
         sys.exit(1)
 
     shutil.copy(filename, filename + '.old~~')
     f = open(filename, 'r')
     filestr = f.read()
     f.close()
-    import doconce
+    from . import doconce
     filestr = doconce.subst_away_inline_comments(filestr)
     f = open(filename, 'w')
     f.write(filestr)
     f.close()
-    print 'inline comments removed in ' + filename
+    print('inline comments removed in ' + filename)
 
 def apply_inline_edits():
     try:
         filename = sys.argv[1]
     except IndexError:
-        print 'Usage: doconce apply_inline_comments_edits myfile.do.txt'
+        print('Usage: doconce apply_inline_comments_edits myfile.do.txt')
         _abort()
 
     if not os.path.isfile(filename):
-        print '*** error: file %s does not exist!' % filename
+        print('*** error: file %s does not exist!' % filename)
         sys.exit(1)
 
     shutil.copy(filename, filename + '.old~~')
@@ -907,7 +919,7 @@ def apply_inline_edits():
     f = open(filename, 'w')
     f.write(filestr)
     f.close()
-    print 'inline comments removed in ' + filename
+    print('inline comments removed in ' + filename)
 
 def latin2html():
     """
@@ -915,15 +927,15 @@ def latin2html():
     in an HTML file. See doconce.html.latin2html for more
     documentation.
     """
-    from doconce.html import latin2html
+    from .doconce.html import latin2html
     import os, shutil, sys
     for filename in sys.argv[1:]:
         if not os.path.isfile(filename):
-            print '*** error: file %s does not exist!' % filename
+            print('*** error: file %s does not exist!' % filename)
             continue
         oldfilename = filename + '.old~~'
         shutil.copy(filename, oldfilename)
-        print 'transformin latin characters to HTML encoding in ' + filename
+        print('transformin latin characters to HTML encoding in ' + filename)
         f = open(oldfilename, 'r')
         try:
             text = f.read()
@@ -932,12 +944,12 @@ def latin2html():
             f = open(filename, 'w')
             f.write(newtext)
             f.close()
-        except Exception, e:
-            print e.__class__.__name__ + ' : ' + str(e)
+        except Exception as e:
+            print(e.__class__.__name__ + ' : ' + str(e))
 
 # replace is taken from scitools
 def _usage_find_nonascii_chars():
-    print 'Usage: doconce find_nonascii_chars file1 file2 ...'
+    print('Usage: doconce find_nonascii_chars file1 file2 ...')
 
 def find_nonascii_chars():
     if len(sys.argv) <= 1:
@@ -950,13 +962,13 @@ def find_nonascii_chars():
             with open(filename, 'r') as f:
                 text = f.read()
         else:
-            print 'File %s not found' % filename
+            print('File %s not found' % filename)
             sys.exit(1)
         for i, c in enumerate(text):
             if ord(c) > 127:
-                print 'non-ascii character', c, ' (ord=%d)' % ord(c)
-                print 'appearing in the text from %s:' % filename
-                print text[i-40:i], '--> %s <--' % c, text[i:i+40]
+                print('non-ascii character', c, ' (ord=%d)' % ord(c))
+                print('appearing in the text from %s:' % filename)
+                print(text[i-40:i], '--> %s <--' % c, text[i:i+40])
 
 
 
@@ -965,12 +977,12 @@ def gwiki_figsubst():
         gwikifile = sys.argv[1]
         URLstem = sys.argv[2]
     except IndexError:
-        print 'Usage: %s wikifile URL-stem' % sys.argv[0]
-        print 'Ex:    %s somefile.gwiki http://code.google.com/p/myproject/trunk/doc/somedir' % sys.argv[0]
+        print('Usage: %s wikifile URL-stem' % sys.argv[0])
+        print('Ex:    %s somefile.gwiki http://code.google.com/p/myproject/trunk/doc/somedir' % sys.argv[0])
         _abort()
 
     if not os.path.isfile(gwikifile):
-        print '*** error: file %s does not exist!' % gwikifile
+        print('*** error: file %s does not exist!' % gwikifile)
         sys.exit(1)
 
     # first grep out all filenames with local path:
@@ -988,19 +1000,19 @@ def gwiki_figsubst():
     f = open(gwikifile, 'w')
     f.write(fstr)
     f.close()
-    print 'Replaced %d figure references in %s' % (n, gwikifile)
+    print('Replaced %d figure references in %s' % (n, gwikifile))
     if n != n2:
-        print 'Something strange: %d fig references and %g comments... Bug.' % (n, n2)
+        print('Something strange: %d fig references and %g comments... Bug.' % (n, n2))
 
 
 
 # subst is taken from scitools
 def _usage_subst():
-    print 'Usage: doconce subst [-s -m -x --restore] pattern replacement file1 file2 file3 ...'
-    print '--restore brings back the backup files'
-    print '-s is the re.DOTALL or re.S modifier'
-    print '-m is the re.MULTILINE or re.M modifier'
-    print '-x is the re.VERBODE or re.X modifier'
+    print('Usage: doconce subst [-s -m -x --restore] pattern replacement file1 file2 file3 ...')
+    print('--restore brings back the backup files')
+    print('-s is the re.DOTALL or re.S modifier')
+    print('-m is the re.MULTILINE or re.M modifier')
+    print('-x is the re.VERBODE or re.X modifier')
 
 def _scitools_subst(patterns, replacements, filenames,
                     pattern_matching_modifiers=0):
@@ -1032,7 +1044,7 @@ def _scitools_subst(patterns, replacements, filenames,
 
     for filename in filenames:
         if not os.path.isfile(filename):
-            print '*** error: file %s does not exist!' % filename
+            print('*** error: file %s does not exist!' % filename)
             continue
         f = open(filename, 'r');
         filestr = f.read()
@@ -1083,7 +1095,7 @@ def subst():
     from getopt import getopt
     optlist, args = getopt(sys.argv[1:], 'smx', ['restore'])
     if not args:
-        print 'no filename(s) given'
+        print('no filename(s) given')
         sys.exit(1)
 
     restore = False
@@ -1105,18 +1117,18 @@ def subst():
         for oldfile in args:
             newfile = re.sub(r'\.old~~$', '', oldfile)
             if not os.path.isfile(oldfile):
-                print '%s is not a file!' % oldfile; continue
+                print('%s is not a file!' % oldfile); continue
             os.rename(oldfile, newfile)
-            print 'restoring %s as %s' % (oldfile,newfile)
+            print('restoring %s as %s' % (oldfile,newfile))
     else:
         pattern = args[0]; replacement = args[1]
         s = _scitools_subst(pattern, replacement,
                             wildcard_notation(args[2:]), pmm)
-        print s  # print info about substitutions
+        print(s)  # print info about substitutions
 
 # replace is taken from scitools
 def _usage_replace():
-    print 'Usage: doconce replace from-text to-text file1 file2 ...'
+    print('Usage: doconce replace from-text to-text file1 file2 ...')
 
 def replace():
     if len(sys.argv) < 4:
@@ -1128,7 +1140,7 @@ def replace():
     filenames = wildcard_notation(sys.argv[3:])
     for filename in filenames:
         if not os.path.isfile(filename):
-            print '*** error: file %s does not exist!' % filename
+            print('*** error: file %s does not exist!' % filename)
             continue
         f = open(filename, 'r')
         text = f.read()
@@ -1136,21 +1148,21 @@ def replace():
         if from_text in text:
             backup_filename = filename + '.old~~'
             shutil.copy(filename, backup_filename)
-            print 'replacing %s by %s in %s' % (from_text, to_text, filename)
+            print('replacing %s by %s in %s' % (from_text, to_text, filename))
             text = text.replace(from_text, to_text)
             f = open(filename, 'w')
             f.write(text)
             f.close()
 
 def _usage_replace_from_file():
-    print """Usage: doconce replace_from_file file-with-from-to file1 file2 ...
+    print("""Usage: doconce replace_from_file file-with-from-to file1 file2 ...
 
 The file must contain two columns with the from and to parts
 for each substitution. Comment lines starting with # are allowed.
 The output from doconce list_labels has a form suitable for
 being extended with a second column with new labels and run
 with this command to clean up label names.
-"""
+""")
 
 def replace_from_file():
     """
@@ -1194,7 +1206,7 @@ def replace_from_file():
                 if from_text in text:
                     backup_filename = filename + '.old~~'
                     shutil.copy(filename, backup_filename)
-                    print 'replacing %s by %s in %s' % (from_text, to_text, filename)
+                    print('replacing %s by %s in %s' % (from_text, to_text, filename))
                     text = text.replace(from_text, to_text)
                     replacements = True
         if replacements:
@@ -1203,13 +1215,13 @@ def replace_from_file():
             f.close()
 
 def _usage_find():
-    print """Usage: doconce find expression
+    print("""Usage: doconce find expression
 
 Searches for all .do.txt files in subdirectories and
 writes out filename, line number and line containing expression
 expression is interpreted as a regular expression
 (the command is similar to a Unix find & grep)
-"""
+""")
 
 def find():
     if len(sys.argv) < 2:
@@ -1226,14 +1238,14 @@ def find():
                         m = re.search(expression, line)
                         if m:
                             if not found:
-                                print # newline between files
-                            print '%s, %4d: %s' % (filename, i+1, m.group())
+                                print() # newline between files
+                            print('%s, %4d: %s' % (filename, i+1, m.group()))
                             found = True
 
 
 def _usage_include_map():
-    print 'Usage: doconce include_map mydoc.do.txt'
-    print 'List all recursive includes in mydoc.do.txt'
+    print('Usage: doconce include_map mydoc.do.txt')
+    print('List all recursive includes in mydoc.do.txt')
 
 def include_map():
     if len(sys.argv) < 2:
@@ -1245,7 +1257,7 @@ def include_map():
 
     def find_include(name, indent=''):
         if not os.path.isfile(name):
-            print '*** file "%s" was not found!' % name
+            print('*** file "%s" was not found!' % name)
             # Could be non-existing or the filename may contain
             # preprocess variable(s)
             return
@@ -1255,17 +1267,17 @@ def include_map():
             if '#include ' in line:
                 includefile = line.split('#include')[1].strip()[1:-1]
                 includefile = os.path.join(os.path.dirname(name), includefile)
-                print indent + ' #include ' + includefile
+                print(indent + ' #include ' + includefile)
                 find_include(includefile, indent + '    ')
 
-    print filename
+    print(filename)
     find_include(filename)
 
 
 
 def _usage_expand_mako():
-    print 'Usage: doconce expand_mako mako_code_file.txt funcname mydoc.do.txt'
-    print '(Replaces mako calls to functions by the function bodies)'
+    print('Usage: doconce expand_mako mako_code_file.txt funcname mydoc.do.txt')
+    print('(Replaces mako calls to functions by the function bodies)')
 
 # This replacement function for re.sub must be global since expand_mako,
 # where it is used, has an exec statement
@@ -1296,13 +1308,13 @@ def expand_mako():
                 inside_func = False
 
     funcname_text = '\n'.join(func_lines)
-    print 'Extracted function %s from %s:\n' % (funcname, mako_filename) + funcname_text
-    print func_lines
+    print('Extracted function %s from %s:\n' % (funcname, mako_filename) + funcname_text)
+    print(func_lines)
     try:
         exec(funcname_text)
     except Exception as e:
-        print '*** error: could not turn function code into a Python function'
-        print e
+        print('*** error: could not turn function code into a Python function')
+        print(e)
         _abort()
         # Note: if funcname has FORMAT tests the exec will fail, but
         # one can make an alternative version of funcname in another file
@@ -1317,7 +1329,7 @@ def expand_mako():
         if not filename.endswith('.do.txt'):
             filename += '.do.txt'
         if not os.path.isfile(filename):
-            print '*** error: file %s does not exist!' % filename
+            print('*** error: file %s does not exist!' % filename)
             continue
         f = open(filename, 'r')
         text = f.read()
@@ -1326,13 +1338,13 @@ def expand_mako():
         if m:
             backup_filename = filename + '.old~~'
             shutil.copy(filename, backup_filename)
-            print 'expanding mako function %s in %s' % (funcname, filename)
+            print('expanding mako function %s in %s' % (funcname, filename))
             calls = re.findall(pattern, text, flags=re.DOTALL)
             for mako_call, python_call in calls:
                 try:
                     replacement = eval(python_call)
                 except Exception as e:
-                    print '*** error: could not run call\n%s' % python_call
+                    print('*** error: could not run call\n%s' % python_call)
                     _abort()
                 text = text.replace(mako_call, replacement)
 
@@ -1341,14 +1353,14 @@ def expand_mako():
             f.close()
 
 def _usage_linkchecker():
-    print 'Usage: doconce linkchecker file1.html|file1.do.txt|tmp_mako__file1.do.txt ...'
-    print 'Check if URLs or links to local files in DocOnce or HTML files are valid.'
+    print('Usage: doconce linkchecker file1.html|file1.do.txt|tmp_mako__file1.do.txt ...')
+    print('Check if URLs or links to local files in DocOnce or HTML files are valid.')
 
 def linkchecker():
     if len(sys.argv) <= 1:
         _usage_linkchecker()
         sys.exit(0)
-    from common import is_file_or_url
+    from .common import is_file_or_url
     prefix = '(file:///|https?://|ftp://)'
     pattern_html = r'href="(%s.+?)"' % prefix
     pattern_do = r'''"[^"]+?" ?:\s*"(%s.+?)"''' % prefix
@@ -1356,7 +1368,7 @@ def linkchecker():
     for filename in sys.argv[1:]:
         ext = os.path.splitext(filename)[1]
         if not ext in ('.html', '.htm', '.txt'):
-            print '*** error: %s is not a DocOnce or HTML file' % filename
+            print('*** error: %s is not a DocOnce or HTML file' % filename)
             continue
         f = open(filename, 'r')
         text = f.read()
@@ -1370,20 +1382,20 @@ def linkchecker():
         for link in links:
             check = is_file_or_url(link, msg=None)
             if check in ('file', 'url'):
-                print '%s:' % filename + ' ' + link + ' exists as ' + check
+                print('%s:' % filename + ' ' + link + ' exists as ' + check)
             else:
-                print '%s:' % filename + ' ' + link + ' WAS NOT FOUND'
+                print('%s:' % filename + ' ' + link + ' WAS NOT FOUND')
                 missing[-1][1].append(link)
     for filename, missing_links in missing:
         if missing_links:
-            print '\n\n*** missing links in %s:\n%s' % \
+            print('\n\n*** missing links in %s:\n%s' % \
                   (filename, '\n'.join(['"%s"' % link
-                                        for link in missing_links]))
+                                        for link in missing_links])))
 
 
 def _dofix_localURLs(filename, exclude_adr):
     if os.path.splitext(filename)[1] != '.rst':
-        print 'Wrong filename extension in "%s" - must be a .rst file' % filename
+        print('Wrong filename extension in "%s" - must be a .rst file' % filename)
         _abort()
 
     f = open(filename, 'r')
@@ -1402,9 +1414,9 @@ def _dofix_localURLs(filename, exclude_adr):
     num_fixed_links = 0
     for link in links:
         if link in exclude_adr:
-            print 'not modifying ' + link
+            print('not modifying ' + link)
             if link.endswith('htm') or link.endswith('html'):
-                print 'Note: %s\n      is an HTML file that may link to other files.\n      This may require copying many files! Better: link to _static directly in the doconce document.' % link
+                print('Note: %s\n      is an HTML file that may link to other files.\n      This may require copying many files! Better: link to _static directly in the doconce document.' % link)
             continue
         if not (link.startswith('http') or link.startswith('file:/') or \
             link.startswith('_static')):
@@ -1413,11 +1425,11 @@ def _dofix_localURLs(filename, exclude_adr):
                     os.mkdir('_static')
                 newlink = os.path.join('_static', os.path.basename(link))
                 text = text.replace('<%s>' % link, '<%s>' % newlink)
-                print 'fixing link to %s as link to %s' % (link, newlink)
-                print '       copying %s to _static' % os.path.basename(link)
+                print('fixing link to %s as link to %s' % (link, newlink))
+                print('       copying %s to _static' % os.path.basename(link))
                 shutil.copy(link, newlink)
                 if link.endswith('htm') or link.endswith('html'):
-                    print 'Note: %s\n      is an HTML file that may link to other files.\n      This may require copying many files! Better: link to _static directly in the doconce document.' % link
+                    print('Note: %s\n      is an HTML file that may link to other files.\n      This may require copying many files! Better: link to _static directly in the doconce document.' % link)
                 num_fixed_links += 1
     if num_fixed_links > 0:
         os.rename(filename, filename + 'old~~')
@@ -1428,7 +1440,7 @@ def _dofix_localURLs(filename, exclude_adr):
 
 
 def _usage_sphinxfix_localURLs():
-    print"""
+    print("""
 Usage: doconce sphinxfix_localURLs file1.rst file2.rst ... -not adr1 adr2 ...
 
 Each link to a local file, e.g., "link": "src/dir1/myfile.txt",
@@ -1454,7 +1466,7 @@ directly to _static.
 
 In general, it is better to link to _static from the DocOnce document
 rather than relying on the fixes in this script...
-"""
+""")
 
 def sphinxfix_localURLs():
     if len(sys.argv) < 2:
@@ -1472,15 +1484,15 @@ def sphinxfix_localURLs():
 
     for filename in sys.argv[1:]:
         if os.path.dirname(filename) != '':
-            print 'doconce sphinxfix_localURLs must be run from the same directory as %s is located in' % filename
+            print('doconce sphinxfix_localURLs must be run from the same directory as %s is located in' % filename)
         num_fixed_links = _dofix_localURLs(filename, exclude_adr)
         if num_fixed_links > 0:
-            print "\nYou must copy _static/* to the sphinx directory's _static directory"
+            print("\nYou must copy _static/* to the sphinx directory's _static directory")
 
 
 def _usage_latex_exercise_toc():
-    print 'Usage: doconce latex_exercise_toc myfile.do.txt ["List of exercises"]'
-    print """
+    print('Usage: doconce latex_exercise_toc myfile.do.txt ["List of exercises"]')
+    print("""
 Can insert
 # Short: My own short title
 in the text of an exercise and this defines a short version of the
@@ -1490,7 +1502,7 @@ fails (happens if truncated in the middle of mathematical $...$
 constructions). Any short title is appearing in the table exactly
 how it is written, so this is also a method to avoid truncating
 a title.
-"""
+""")
 
 def latex_exercise_toc():
     if len(sys.argv) < 2:
@@ -1501,7 +1513,7 @@ def latex_exercise_toc():
         dofile = dofile[:-7]
     exerfile = '.' + dofile + '.exerinfo'
     if not os.path.isfile(exerfile):
-        print 'no file %s with exercises from %s found' % (exerfile, dofile)
+        print('no file %s with exercises from %s found' % (exerfile, dofile))
         return
 
     f = open(exerfile, 'r')
@@ -1578,7 +1590,7 @@ def latex_exercise_toc():
         if os.path.isfile(texfile):
             f = open(texfile, 'r')
         else:
-            print '*** error: no .tex or .p.tex file for %s' % dofile
+            print('*** error: no .tex or .p.tex file for %s' % dofile)
             sys.exit(1)
     shutil.copy(texfile, texfile + '.old~~')
     filestr = f.read()
@@ -1589,15 +1601,15 @@ def latex_exercise_toc():
                          filestr, flags=re.MULTILINE)
         f = open(texfile, 'w')
         f.write(filestr)
-        print 'table of exercises inserted in ' + texfile
+        print('table of exercises inserted in ' + texfile)
         f.close()
     else:
-        print '*** error: cannot insert table of exercises because there is no'
-        print '    table of contents requested in the ' + dofile + ' document'
+        print('*** error: cannot insert table of exercises because there is no')
+        print('    table of contents requested in the ' + dofile + ' document')
 
 
 def _usage_combine_images():
-    print """\
+    print("""\
 Usage: doconce combine_images [pdf|png] [-4] image1 image2 ... output_file
 Applies montage if not PDF or EPS images, else
 pdftk, pdfnup and pdfcrop.
@@ -1607,7 +1619,7 @@ The first command-line argument can be a file extension and
 the filenames can then be given without extension:
 
 doconce combine_images pdf -2 u1 u2 u12
-"""
+""")
 
 def combine_images():
 
@@ -1637,7 +1649,7 @@ def combine_images():
 
     for name in imagefiles:
         if not os.path.isfile(name):
-            print '*** error: file "%s" is non-existing' % name
+            print('*** error: file "%s" is non-existing' % name)
             _abort()
     output_file = sys.argv[-1]
     basename, ext = os.path.splitext(output_file)
@@ -1666,20 +1678,20 @@ def combine_images():
                 imagefiles[i] = f.replace('.eps', '.pdf')
 
         # Combine PDF images
-        num_rows = int(round(len(imagefiles)/float(num_columns)))
+        num_rows = int(round(old_div(len(imagefiles),float(num_columns))))
         cmds.append('pdftk %s output tmp.pdf' % ' '.join(imagefiles))
         cmds.append('pdfnup --nup %dx%d --outfile tmp.pdf tmp.pdf' % (num_columns, num_rows))
         cmds.append('pdfcrop tmp.pdf %s' % output_file)
         cmds.append('rm -f tmp.pdf')
-    print
+    print()
     for cmd in cmds:
         system(cmd, verbose=True)
-    print 'output in ' + output_file
+    print('output in ' + output_file)
 
 
 def _usage_expand_commands():
-    print 'Usage: doconce expand_commands file1 file2 ...'
-    print """
+    print('Usage: doconce expand_commands file1 file2 ...')
+    print("""
 A file .expand_commands may define _replace and _regex_subst lists
 for str.replace and re.sub substitutions (respectively) to be applied
 to file1 file2 ...
@@ -1695,7 +1707,7 @@ _replace = [
 ]
 
 _regex_subst = []
-"""
+""")
 
 def expand_commands():
     if len(sys.argv) < 2:
@@ -1741,20 +1753,20 @@ def expand_commands():
         for from_, to_ in replace:
             if from_ in text:
                 text = text.replace(from_, to_)
-                print 'replacing %s by %s in %s' % (from_, to_, filename)
+                print('replacing %s by %s in %s' % (from_, to_, filename))
                 changed = True
         for item in regex_subst:
             if len(item) == 2:
                 from_, to_ = item
                 if re.search(from_, text):
                     text = re.sub(from_, to_, text)
-                    print 'substituting %s by %s in %s' % (from_, to_, filename)
+                    print('substituting %s by %s in %s' % (from_, to_, filename))
                     changed = True
             elif len(item) == 3:
                 frm_, to_, modifier = item
                 if re.search(from_, text, flags=modifier):
                     text = re.sub(from_, to_, text, flags=modifier)
-                    print 'substituting %s by %s in %s' % (from_, to_, filename)
+                    print('substituting %s by %s in %s' % (from_, to_, filename))
                     changed = True
         if changed:
             shutil.copy(filename, filename + '.old~~')
@@ -1770,7 +1782,7 @@ def copy_latex_packages(packages):
     """
     datafile = latexstyle_files  # global variable (latex_styles.zip)
     missing_files = []
-    import commands
+    import subprocess
     for style in packages:
         stem, ext = os.path.splitext(style)
         if ext == '':
@@ -1786,9 +1798,9 @@ def copy_latex_packages(packages):
             missing_files.append(style)
     if missing_files:
         # Copy zipfile with styles to current dir
-        print '*** missing style files:'
-        print '    ' + ', '.join(missing_files)
-        import doconce
+        print('*** missing style files:')
+        print('    ' + ', '.join(missing_files))
+        from . import doconce
         doconce_dir = os.path.dirname(doconce.__file__)
         doconce_datafile = os.path.join(doconce_dir, datafile)
         shutil.copy(doconce_datafile, os.curdir)
@@ -1801,13 +1813,13 @@ def copy_latex_packages(packages):
                 msg = 'extracted'
             except:
                 msg = 'could not extract'
-            print '%s %s (from %s in the doconce installation)' % \
-                  (msg, filename, latexstyle_files)
+            print('%s %s (from %s in the doconce installation)' % \
+                  (msg, filename, latexstyle_files))
     if os.path.isfile(datafile):
         os.remove(datafile)
 
 def _usage_ptex2tex():
-    print r"""\
+    print(r"""\
 Usage: doconce ptex2tex [file | file.p.tex] [-Dvar1=val1 ...] \
        [cod=\begin{quote}\begin{verbatim}@\end{verbatim}\end{quote} \
         pypro=Verbatim fcod=minted ccod=ans cpppro=anslistings:nt]'
@@ -1847,7 +1859,7 @@ If environment is simply the string "envir", the value applies to all
 registered environments. Specifying (e.g.) sys=... and then envir=ans,
 will substitute the sys environment by the specified syntax and all
 other environments will apply the latex construct from anslistings.sty.
-"""
+""")
 
 def ptex2tex():
     if len(sys.argv) <= 1:
@@ -1858,7 +1870,7 @@ def ptex2tex():
     if filename.endswith('.p.tex'):
         filename = filename[:-6]
     if not os.path.isfile(filename + '.p.tex'):
-        print 'no file %s' % (filename + '.p.tex')
+        print('no file %s' % (filename + '.p.tex'))
         _abort()
     f = open(filename + '.p.tex', 'r')
     ptex2tex_filestr = f.read()
@@ -1876,7 +1888,7 @@ def ptex2tex():
 
     # Accept all envirs in envir2pygments, plus all
     # registered lexers in pygments
-    from common import get_legal_pygments_lexers
+    from .common import get_legal_pygments_lexers
     ptex2tex_begin_pattern = r'^\\b([a-z0-9+_]+)$'
     user_envirs = re.findall(ptex2tex_begin_pattern, ptex2tex_filestr,
                              flags=re.MULTILINE)
@@ -2039,7 +2051,7 @@ def ptex2tex():
             if latexenvir in latexenvir2package:
                 packages.add(latexenvir2package[latexenvir])
             else:
-                print 'No package known for latex environment "%s" ' % latexenvir
+                print('No package known for latex environment "%s" ' % latexenvir)
     packages = list(packages)
     # fancyvrb is needed for \code{...} -> \Verb!...! translation
     if not 'fancyvrb' in packages:
@@ -2069,7 +2081,7 @@ download preprocess from http://code.google.com/p/preprocess""")
     f.close()
 
     # Replace the environments specified by the user
-    from latex import fix_latex_command_regex
+    from .latex import fix_latex_command_regex
     for envir, begin, end in envir_user_spec:
         for postfix in ['cod', 'pro', '']:
             ptex2tex_begin = '\\' + 'b' + envir + postfix
@@ -2086,7 +2098,7 @@ download preprocess from http://code.google.com/p/preprocess""")
                     end_pattern,
                     fix_latex_command_regex(end, application='replacement'),
                     filestr, flags=re.MULTILINE)
-                print '%s (!bc %s) -> %s\n' % (ptex2tex_begin, envir, begin)
+                print('%s (!bc %s) -> %s\n' % (ptex2tex_begin, envir, begin))
 
     # Replace other environments by a default choice
     begin = r"""\begin{Verbatim}[numbers=none,fontsize=\fontsize{9pt}{9pt},baselinestretch=0.95]"""
@@ -2108,7 +2120,7 @@ download preprocess from http://code.google.com/p/preprocess""")
                 end_pattern,
                 fix_latex_command_regex(end, application='replacement'),
                 filestr, flags=re.MULTILINE)
-            print '%s (!bc %s) -> %s ("%s" is unsupported so we use Verbatim)\n' % (ptex2tex_begin, envir, begin, envir)
+            print('%s (!bc %s) -> %s ("%s" is unsupported so we use Verbatim)\n' % (ptex2tex_begin, envir, begin, envir))
 
     # Make sure we include the necessary verbatim packages
     if packages:
@@ -2134,13 +2146,13 @@ download preprocess from http://code.google.com/p/preprocess""")
             output = subprocess.check_output(cmd, shell=True,
                                              stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:
-            print """You have requested the minted latex style, but this
+            print("""You have requested the minted latex style, but this
 requires the pygments package to be installed. On Debian/Ubuntu: run
 Terminal> sudo apt-get install python-pygments
 Or
 Terminal> hg clone http://bitbucket.org/birkenfeld/pygments-main pygments
 Terminal> cd pygments; sudo python setup.py install
-"""
+""")
             _abort()
 
     filestr = replace_code_command(filestr)
@@ -2148,7 +2160,7 @@ Terminal> cd pygments; sudo python setup.py install
     f = open(output_filename, 'w')
     f.write(filestr)
     f.close()
-    print 'output in ' + output_filename
+    print('output in ' + output_filename)
 
 def replace_code_command(filestr):
     """Replace \code{...} by \Verb!...! or \textttt{...}."""
@@ -2173,7 +2185,7 @@ def replace_code_command(filestr):
                     break
             if alt_verb_delimiter is None:
                 alt_verb_delimiter = alt_verb_delimiters[0]
-                print """
+                print("""
 *** warning: inline verbatim "%s"
     contains all delimiters %s that the LaTeX
     command \\Verb can make use of - be prepared for strange output that
@@ -2181,7 +2193,7 @@ def replace_code_command(filestr):
     \\Verb%s%s%s
     or move this line verbatim expression to a code block !bc ... !ec.
 """ % (verbatim, [verb_delimiter] + list(alt_verb_delimiter),
-       alt_verb_delimiter, verbatim, alt_verb_delimiter)
+       alt_verb_delimiter, verbatim, alt_verb_delimiter))
             # Here one can have a problem in that verbatim contains
             # special regex chars such as $, \, ., etc. Use re.escape
             pattern = re.escape(r'\code{%s}' % verbatim) + r"""([ \n,.;:?!)"'-])"""
@@ -2217,7 +2229,7 @@ def replace_code_command(filestr):
     return filestr
 
 def _usage_grab():
-    print 'Usage: doconce grab --from[-] from-text [--to[-] to-text] file'
+    print('Usage: doconce grab --from[-] from-text [--to[-] to-text] file')
 
 def grab():
     """
@@ -2236,7 +2248,7 @@ def grab():
 
     filename = sys.argv[-1]
     if not sys.argv[1].startswith('--from'):
-        print 'missing --from fromtext or --from_ fromtext option on the command line'
+        print('missing --from fromtext or --from_ fromtext option on the command line')
         _abort()
     from_included = sys.argv[1] == '--from'
     from_text = sys.argv[2]
@@ -2273,12 +2285,12 @@ def grab():
         elif copy:
             lines.append(line)
     if not from_found:
-        print 'Could not find match for from regex "%s"' % from_text
+        print('Could not find match for from regex "%s"' % from_text)
         sys.exit(1)
     if not to_found and to_text != impossible_text:
-        print 'Could not find match for to   regex "%s"' % to_text
+        print('Could not find match for to   regex "%s"' % to_text)
         sys.exit(1)
-    print ''.join(lines).rstrip()
+    print(''.join(lines).rstrip())
 
 def remove_text(filestr, from_text, from_included, to_text, to_included):
     """
@@ -2310,7 +2322,7 @@ def remove_text(filestr, from_text, from_included, to_text, to_included):
     return '\n'.join(lines).rstrip() + '\n', from_found, to_found
 
 def _usage_remove():
-    print 'Usage: doconce remove --from[-] from-text [--to[-] to-text] file'
+    print('Usage: doconce remove --from[-] from-text [--to[-] to-text] file')
 
 def remove():
     """
@@ -2333,7 +2345,7 @@ def remove():
     f.close()
 
     if not sys.argv[1].startswith('--from'):
-        print 'missing --from fromtext or --from_ fromtext option on the command line'
+        print('missing --from fromtext or --from_ fromtext option on the command line')
         sys.exit(1)
     from_included = sys.argv[1] == '--from'
     from_text = sys.argv[2]
@@ -2354,10 +2366,10 @@ def remove():
         filestr, from_text, from_included, to_text, to_included)
 
     if not from_found:
-        print 'Could not find match for from regex "%s"' % from_text
+        print('Could not find match for from regex "%s"' % from_text)
         sys.exit(1)
     if not to_found and to_text != impossible_text:
-        print 'Could not find match for to   regex "%s"' % to_text
+        print('Could not find match for to   regex "%s"' % to_text)
         sys.exit(1)
 
     os.rename(filename, filename + '.old~~')
@@ -2366,7 +2378,7 @@ def remove():
     f.close()
 
 def _usage_remove_exercise_answers():
-    print 'Usage: doconce remove_exercise_answers file_in_some_format'
+    print('Usage: doconce remove_exercise_answers file_in_some_format')
 
 def remove_exercise_answers():
     if len(sys.argv) < 2:
@@ -2387,7 +2399,7 @@ def remove_exercise_answers():
     if from_found and to_found:
         pass
     else:
-        print 'no answers/solutions to exercises found in ' + filename
+        print('no answers/solutions to exercises found in ' + filename)
 
     os.rename(filename, filename + '.old~~')
     f = open(filename, 'w')
@@ -2415,9 +2427,9 @@ def _clean(light):
     splitting (split_html, split_rst).
     """
     if os.path.isdir('Trash'):
-        print
+        print()
         shutil.rmtree('Trash')
-        print 'Removing Trash directory'
+        print('Removing Trash directory')
     removed = []
 
     trash_files = ['_doconce_debugging.log', '__tmp.do.txt', 'texput.log']
@@ -2470,21 +2482,21 @@ def _clean(light):
             removed.append(d)
 
     if removed:
-        print 'Remove: ' + ' '.join(removed) + ' (-> Trash)'
+        print('Remove: ' + ' '.join(removed) + ' (-> Trash)')
         os.mkdir('Trash')
         for f in removed:
             try:
                 shutil.move(f, 'Trash')
-            except shutil.Error, e:
+            except shutil.Error as e:
                 if 'already exists' in str(e):
                     pass
                 else:
-                    print 'Move problems with %s %s' % (f, e)
+                    print('Move problems with %s %s' % (f, e))
             if os.path.isdir(f):
                 shutil.rmtree(f)
 
 def _usage_guess_encoding():
-    print 'Usage: doconce guess_encoding filename'
+    print('Usage: doconce guess_encoding filename')
 
 def _encoding_guesser(filename, verbose=False):
     """Try to guess the encoding of a file."""
@@ -2497,11 +2509,11 @@ def _encoding_guesser(filename, verbose=False):
     for encoding in encodings:
         try:
             if verbose:
-                print 'Trying encoding ' + encoding + ' with unicode(text, encoding)'
-            unicode(text, encoding, "strict")
-        except Exception, e:
+                print('Trying encoding ' + encoding + ' with unicode(text, encoding)')
+            str(text, encoding, "strict")
+        except Exception as e:
             if verbose:
-                print 'failed: %s' % e
+                print('failed: %s' % e)
         else:
             break
     return encoding
@@ -2511,11 +2523,11 @@ def guess_encoding():
         _usage_guess_encoding()
         sys.exit(0)
     filename = sys.argv[1]
-    print _encoding_guesser(filename, verbose=False)
+    print(_encoding_guesser(filename, verbose=False))
 
 def _usage_change_encoding():
-    print 'Usage: doconce change_encoding from-encoding to-encoding file1 file2 ...'
-    print 'Example: doconce change_encoding utf-8 latin1 myfile.do.txt'
+    print('Usage: doconce change_encoding from-encoding to-encoding file1 file2 ...')
+    print('Example: doconce change_encoding utf-8 latin1 myfile.do.txt')
 
 def _change_encoding_unix(filename, from_enc, to_enc):
     backupfile = filename + '.old~~'
@@ -2526,7 +2538,7 @@ def _change_encoding_unix(filename, from_enc, to_enc):
         cmd = 'iconv -f %s -t %s %s > %s' % \
               (from_enc, to_enc, backupfile, filename)
     else:
-        print 'changing encoding is not implemented on Windows machines'
+        print('changing encoding is not implemented on Windows machines')
         _abort()
     os.rename(filename, backupfile)
     failure = system(cmd, abort_on_failure=False)
@@ -2582,12 +2594,12 @@ def copy_datafiles(datafile):
         import tarfile
         uncompressor = tarfile.TarFile
     if not os.path.isdir(subdir):
-        import doconce
+        from . import doconce
         doconce_dir = os.path.dirname(doconce.__file__)
         doconce_datafile = os.path.join(doconce_dir, datafile)
         shutil.copy(doconce_datafile, os.curdir)
         uncompressor(datafile).extractall()
-        print 'made subdirectory ' + subdir
+        print('made subdirectory ' + subdir)
         os.remove(datafile)
         return True
     else:
@@ -2595,7 +2607,7 @@ def copy_datafiles(datafile):
 
 
 def _usage_html_colorbullets():
-    print 'Usage: doconce html_colorbullets mydoc.html'
+    print('Usage: doconce html_colorbullets mydoc.html')
 
 def html_colorbullets():
     # A much better implementation, avoiding tables, is given
@@ -2645,7 +2657,7 @@ def html_colorbullets():
         f.close()
 
 def _usage_split_html():
-    print """
+    print("""
 Usage: doconce split_html mydoc.html --method=... --nav_button=name --pagination --reference="acknowledgment/author" --font_size=slides --copyright=everypage|titlepage
 
 --method=split|space8|hrule|colorline specifies pagebreak
@@ -2685,7 +2697,7 @@ Example:
 every page (if {copyright...} is specified as part of AUTHOR commands).
 With --copyright=titlepage (default), the copyright only appears on
 the title page only.
-"""
+""")
 
 def split_html():
     """
@@ -2736,8 +2748,8 @@ def split_html():
         parts = tablify(parts, "html")
 
         files = doconce_split_html(header, parts, footer, basename, filename)
-        print '%s now links to the generated files' % filename
-        print ', '.join(files)
+        print('%s now links to the generated files' % filename)
+        print(', '.join(files))
 
     if method != 'split':
         # Remove notes
@@ -2761,13 +2773,13 @@ h2 {font-size: 180%;}
         f.close()
 
         if '<!-- !bslidecell' in filestr:
-            print '*** warning: !bslidecell-!eslidecell constructions are'
-            print '    ignored unless --method=split is specified'
-            print '    (--method=spaceX|hr|hrule|colorline all ignores cells)'
+            print('*** warning: !bslidecell-!eslidecell constructions are')
+            print('    ignored unless --method=split is specified')
+            print('    (--method=spaceX|hr|hrule|colorline all ignores cells)')
 
 
 def _usage_slides_html():
-    print """
+    print("""
 Usage: doconce slides_html mydoc.html slide_type --html_slide_theme=themename --html_footer_logo=name --nav_button=name --font_size=slides --copyright=everypage|titlepage
 
 slide_type: reveal deck csss dzslides
@@ -2822,7 +2834,7 @@ more versatile than slides_html since it allows the --method
 argument, which can be used for physical splits (as in slides_html)
 or "split" via just space or rules for separating the parts in
 one (big) file.
-"""
+""")
 
 def slides_html():
     """
@@ -2860,7 +2872,7 @@ def slides_html():
     if not filename.endswith('.html'):
         filename += '.html'
     if not os.path.isfile(filename):
-        print 'doconce file in html format, %s, does not exist' % filename
+        print('doconce file in html format, %s, does not exist' % filename)
         _abort()
     basename = os.path.basename(filename)
     filestem = os.path.splitext(basename)[0]
@@ -2871,9 +2883,9 @@ def slides_html():
         if arg.startswith('--method='):
             opt = arg.split('=')[1]
             if opt != 'split':
-                print '*** error: slides_html cannot accept --method=%s' % opt
-                print '    (the slides will always be split)'
-                print '    use split_html with --method=...'
+                print('*** error: slides_html cannot accept --method=%s' % opt)
+                print('    (the slides will always be split)')
+                print('    use split_html with --method=...')
                 _abort()
 
     # Treat the special case of generating a script for generating
@@ -2899,7 +2911,7 @@ def slides_html():
                  else:
                      f.write('doconce format html %s --pygments_html_style=%s --keep_pygments_html_bg SLIDE_TYPE=%s SLIDE_THEME=%s\ndoconce slides_html %s %s --html_slide_theme=%s\ncp %s.html %s_%s_%s.html\n\n' % (filestem, pygm_style, sl_tp, style, filestem, sl_tp, style, filestem, filestem, sl_tp, style.replace('.', '_')))
          f.write('echo "Here are the slide shows:"\n/bin/ls %s_*_*.html\n' % filestem)
-         print 'run\n  sh tmp_slides_html_all.sh\nto generate the slides'
+         print('run\n  sh tmp_slides_html_all.sh\nto generate the slides')
          return
 
 
@@ -2915,18 +2927,18 @@ def slides_html():
         filestr = generate_html5_slides(header, parts, footer,
                                         basename, filename, slide_type)
     else:
-        print 'unknown slide type "%s"' % slide_type
+        print('unknown slide type "%s"' % slide_type)
 
     if filestr is not None:
         # Make whitespace nicer (clean up code)
-        from html import html_remove_whitespace
+        from .html import html_remove_whitespace
         filestr = html_remove_whitespace(filestr)
         # More fixes for html5 slides
         filestr = re.sub(r'<section>\s+(?=<h[12])', r'<section>\n', filestr)
         filestr = re.sub(r'<p>\n</section>', '</section>', filestr)
         filestr = re.sub(r'\s+</section>', '\n</section>', filestr)
 
-        from html import html_remove_whitespace
+        from .html import html_remove_whitespace
         filestr = html_remove_whitespace(filestr)
         # More fixes for html5 slides
         filestr = re.sub(r'<section>\s+(?=<h[12])', r'<section>\n', filestr)
@@ -2936,7 +2948,7 @@ def slides_html():
         f = open(filename, 'w')
         f.write(filestr)
         f.close()
-        print 'slides written to ' + filename
+        print('slides written to ' + filename)
 
 
 def tablify(parts, format="html"):
@@ -2993,18 +3005,18 @@ def tablify(parts, format="html"):
                             elif table[r][1][1] is None:
                                 table[r][1][1] = 1 - widths[0]
                         else:
-                            print '*** error: must specify width of all columns in slidecell table!'
-                            print '   ',
+                            print('*** error: must specify width of all columns in slidecell table!')
+                            print('   ', end=' ')
                             for s, c in enumerate(row):
                                 column, width = c
-                                print ' %d%d: ' % (r, s),
+                                print(' %d%d: ' % (r, s), end=' ')
                                 if width is not None:
-                                    print 'no width'
+                                    print('no width')
                                 else:
-                                    print '%g' % width
+                                    print('%g' % width)
                             _abort()
                 else:
-                    width = 1./len(row)
+                    width = old_div(1.,len(row))
                     for s, c in enumerate(row):
                         table[r][s][1] = width
 
@@ -3068,7 +3080,7 @@ def _format_comments(format='html'):
 
 def get_header_parts_footer(filename, format='html'):
     """Return list of lines for header, parts split by !split, and footer."""
-    from doconce import main_content_char
+    from .doconce import main_content_char
     header = []
     footer = []
     parts = [[]]
@@ -3105,7 +3117,7 @@ def doconce_split_html(header, parts, footer, basename, filename, slides=False):
     if html_copyright_placement == 'titlepages':
         html_copyright_placement = 'titlepage'
 
-    import html
+    from . import html
     header_str = '\n'.join(header)
 
     bootstrap = '<!-- Bootstrap style: ' in header_str or \
@@ -3123,7 +3135,7 @@ def doconce_split_html(header, parts, footer, basename, filename, slides=False):
                     text += '<li><a href="%s">&laquo;</a></li>\n' % prev_part_filename
                 max_pagination_pages = 16
                 #max_pagination_pages = 4 # for debugging
-                if len(parts) <= max_pagination_pages/2:
+                if len(parts) <= old_div(max_pagination_pages,2):
                     # Show all pages
                     for i in range(len(parts)):
                         if i == pn:
@@ -3132,12 +3144,12 @@ def doconce_split_html(header, parts, footer, basename, filename, slides=False):
                            text += '  <li><a href="%s">%d</a></li>\n' % (_part_filename % (basename, i) + '.html', i+1)
                 else:
                     # Show first, last, and pages around the current one
-                    if pn >= max_pagination_pages/2 + 2:
+                    if pn >= old_div(max_pagination_pages,2) + 2:
                         i = 0
                         text += '  <li><a href="%s">%d</a></li>\n' % (_part_filename % (basename, i) + '.html', i+1)
                         text += '  <li><a href="">...</a></li>\n'
-                    start = max(0, pn-(max_pagination_pages/2))
-                    stop = min(len(parts), pn+max_pagination_pages/2+2)
+                    start = max(0, pn-(old_div(max_pagination_pages,2)))
+                    stop = min(len(parts), pn+old_div(max_pagination_pages,2)+2)
                     if start == 1:
                         # Special case, add page 1
                         text += '  <li><a href="%s">%d</a></li>\n' % (_part_filename % (basename, 0) + '.html', 0+1)
@@ -3146,7 +3158,7 @@ def doconce_split_html(header, parts, footer, basename, filename, slides=False):
                            text += '  <li class="active"><a href="%s">%d</a></li>\n' % (_part_filename % (basename, i) + '.html', i+1)
                         else:
                            text += '  <li><a href="%s">%d</a></li>\n' % (_part_filename % (basename, i) + '.html', i+1)
-                    if pn <= (len(parts) - (max_pagination_pages/2 + 3)):
+                    if pn <= (len(parts) - (old_div(max_pagination_pages,2) + 3)):
                         text += '  <li><a href="">...</a></li>\n'
                         i = len(parts)-1
                         text += '  <li><a href="%s">%d</a></li>\n' % (_part_filename % (basename, i) + '.html', i+1)
@@ -3210,7 +3222,7 @@ def doconce_split_html(header, parts, footer, basename, filename, slides=False):
     elif nav_button in ('text', 'top', 'bottom', 'top+bottom'):
         pass
     else:
-        print '*** warning: --nav_button=%s is illegal value, text,top+bottom is used' % nav_button
+        print('*** warning: --nav_button=%s is illegal value, text,top+bottom is used' % nav_button)
         nav_button == 'text'
         nav_button_pos = 'top+bottom'
 
@@ -3260,8 +3272,8 @@ def doconce_split_html(header, parts, footer, basename, filename, slides=False):
         for name in parts_href[i]:
             n = parts_name2part.get(name, None) #part where this name is defined
             if n is None and name not in ids:
-                print '*** error: <a href="#%s" has no corresponding anchor (<a name= or some id=)' % name
-                print '    Reasons: 1) wrong reference, 2) no BIBFILE, 2) bug in DocOnce.'
+                print('*** error: <a href="#%s" has no corresponding anchor (<a name= or some id=)' % name)
+                print('    Reasons: 1) wrong reference, 2) no BIBFILE, 2) bug in DocOnce.')
                 _abort()
                 continue  # go to next if abort is turned off
             if n is not None and n != i:
@@ -3311,10 +3323,10 @@ def doconce_split_html(header, parts, footer, basename, filename, slides=False):
                     undefined_labels.append(label)
         if undefined_labels:
             for label in undefined_labels:
-                print '*** error: equation ref (ref{%s}) but no label{%s}' % (label, label)
-            print '*** error: found references to undefined equation labels'
-            print '    (use generalized references ref[][][] if labels are'
-            print '    defined outside this doconce document)'
+                print('*** error: equation ref (ref{%s}) but no label{%s}' % (label, label))
+            print('*** error: found references to undefined equation labels')
+            print('    (use generalized references ref[][][] if labels are')
+            print('    defined outside this doconce document)')
             _abort()
     # Substitute eqrefs in each part.
     # MathJax cannot refer to labels in other HTML files.
@@ -3405,7 +3417,7 @@ def doconce_split_html(header, parts, footer, basename, filename, slides=False):
                                header_copy[k] = header[k].replace(
                                    '<li>', '<li class="active">')
                         else:
-                            print '*** error: doconce bug: wrong syntax in navigation toc for bootstrap styles'
+                            print('*** error: doconce bug: wrong syntax in navigation toc for bootstrap styles')
                             _abort()
 
         lines = header_copy[:]
@@ -4792,21 +4804,21 @@ hr.figure { border: 0; width: 80%%; border-bottom: 1px solid #aaa}
     if not slide_tp in all_combinations:
         # This test will not be run since it is already tested that
         # the slide type is legal (before calling this function)
-        print '*** error: slide type "%s" is not known - abort' % slide_tp
-        print 'known slide types: ' + ', '.join(list(all_combinations.keys()))
+        print('*** error: slide type "%s" is not known - abort' % slide_tp)
+        print('known slide types: ' + ', '.join(list(all_combinations.keys())))
         _abort()
 
     # We need the subdir with reveal.js, deck.js, or similar to show
     # the HTML slides so add the subdir to the registered file collection
     if slide_syntax[slide_tp]['subdir'] is not None:
-        import html
+        from . import html
         html.add_to_file_collection(
             slide_syntax[slide_tp]['subdir'], filename, 'a')
 
     if theme != 'default':
         if not theme in all_combinations[slide_tp]:
-            print '*** error: %s theme "%s" is not known - abort' % (slide_tp, theme)
-            print 'known themes: ' + ', '.join(list(all_combinations[slide_tp].keys()))
+            print('*** error: %s theme "%s" is not known - abort' % (slide_tp, theme))
+            print('known themes: ' + ', '.join(list(all_combinations[slide_tp].keys())))
             _abort()
 
     #m = re.search(r'<title>(.*?)</title>', ''.join(parts[0]))
@@ -5021,12 +5033,12 @@ td.padding {
         if html_style in recommended_combinations:
             if pygm_style != 'plain <pre>' and \
                not pygm_style in recommended_combinations[html_style]:
-                print '*** warning: pygments style "%s" is not '\
-                      'recommended for "%s"!' % (pygm_style, html_style)
-                print 'recommended styles are %s' % \
+                print('*** warning: pygments style "%s" is not '\
+                      'recommended for "%s"!' % (pygm_style, html_style))
+                print('recommended styles are %s' % \
                       (', '.join(['"%s"' % combination
                                   for combination in
-                                  recommended_combinations[html_style]]))
+                                  recommended_combinations[html_style]])))
 
         # Fix styles: native should have black background for dark themes
         if slide_syntax[slide_tp]['theme'] in ['neon', 'night', 'moon', 'blood']:
@@ -5158,7 +5170,7 @@ td.padding {
 
 
 def _usage_slides_beamer():
-    print """Usage: doconce slides_beamer mydoc --beamer_slide_theme=themename --beamer_slide_navigation=off --beamer_block_style=mdbox [--handout])
+    print("""Usage: doconce slides_beamer mydoc --beamer_slide_theme=themename --beamer_slide_navigation=off --beamer_block_style=mdbox [--handout])
 
 themename can be
 red_plain, blue_plain, red_shadow, blue_shadow, dark, dark_gradient, vintage
@@ -5174,7 +5186,7 @@ for simple slide styles.
 
 --handout is used for generating PDF that can be printed as handouts
 (usually after using pdfnup to put multiple slides per sheet).
-"""
+""")
 
 def slides_beamer():
     """
@@ -5190,7 +5202,7 @@ def slides_beamer():
     if not filename.endswith('.tex'):
         filename += '.tex'
     if not os.path.isfile(filename):
-        print 'doconce file in latex format, %s, does not exist - abort' % filename
+        print('doconce file in latex format, %s, does not exist - abort' % filename)
         _abort()
     basename = os.path.basename(filename)
     filestem = os.path.splitext(basename)[0]
@@ -5205,21 +5217,21 @@ def slides_beamer():
         f = open(filename, 'w')
         f.write(filestr)
         f.close()
-        print 'slides written to ' + filename
+        print('slides written to ' + filename)
         if misc_option('handout', False):
-            print 'printing for handout:\npdfnup --nup 2x3 --frame true --delta "1cm 1cm" --scale 0.9 --outfile %s.pdf %s.pdf' % (filestem, filestem)
-            print 'or uncomment %%\pgfpagesuselayout{... in %s.tex' % filestem
+            print('printing for handout:\npdfnup --nup 2x3 --frame true --delta "1cm 1cm" --scale 0.9 --outfile %s.pdf %s.pdf' % (filestem, filestem))
+            print('or uncomment %%\pgfpagesuselayout{... in %s.tex' % filestem)
 
 
 def _usage_slides_markdown():
-    print """
+    print("""
 Usage: doconce slides_markdown mydoc slide_type --slide_theme=dark
 
 slide_type: remark (the only implemented so far)
 --slide_theme: light (default) or dark
 
 Output: mydoc.html
-"""
+""")
 
 def slides_markdown():
     """
@@ -5235,7 +5247,7 @@ def slides_markdown():
     if not filename.endswith('.md'):
         filename += '.md'
     if not os.path.isfile(filename):
-        print 'doconce file in html format, %s, does not exist' % filename
+        print('doconce file in html format, %s, does not exist' % filename)
         _abort()
 
     f = open(filename, 'r')
@@ -5244,7 +5256,7 @@ def slides_markdown():
 
     slide_type = sys.argv[2]
     if slide_type != 'remark':
-        print '*** error: only remark slides are allowed, not %s' % slide_type
+        print('*** error: only remark slides are allowed, not %s' % slide_type)
 
     template = """
 <!DOCTYPE html>
@@ -5339,7 +5351,7 @@ code {
         filestr = re.sub(r'^\$\$\n+(.+?)\$\$\n+', subst,
                          filestr, flags=re.MULTILINE|re.DOTALL)
         # Insert MathJax script and newcommands
-        from html import mathjax_header
+        from .html import mathjax_header
         mathjax = mathjax_header(filestr)
 
     # Fixes
@@ -5383,8 +5395,8 @@ code {
                      flags=re.MULTILINE)
 
     if '<!-- !bslidecell' in filestr:
-        print '*** warning: !bslidecell-!eslidecell does not work with remark slides'
-        print '    (all cells will be placed in their own row...)'
+        print('*** warning: !bslidecell-!eslidecell does not work with remark slides')
+        print('    (all cells will be placed in their own row...)')
 
     if theme == 'dark':
         filestr = filestr.replace('<!-- !split -->', '---\nclass: inverse\n')
@@ -5396,7 +5408,7 @@ code {
     f = open(filename, 'w')
     f.write(template)
     f.close()
-    print '%s slides in %s' % (slide_type, filename)
+    print('%s slides in %s' % (slide_type, filename))
 
 def generate_beamer_slides(header, parts, footer, basename, filename):
     # Styles: red/blue_plain/shadow, dark, dark_gradient, vintage
@@ -5599,8 +5611,8 @@ def generate_beamer_slides(header, parts, footer, basename, filename):
     # plus the newcommands and \begin{document}
     preamble_divider_line = '% --- end of standard preamble for documents ---'
     if preamble_divider_line not in header:
-        print '*** error: generated latex document has missing'
-        print '    title, author, and date - add TITLE:, AUTHOR:, DATE:'
+        print('*** error: generated latex document has missing')
+        print('    title, author, and date - add TITLE:, AUTHOR:, DATE:')
         _abort()
     slides += header.split(preamble_divider_line)[1]
 
@@ -5711,8 +5723,8 @@ def generate_beamer_slides(header, parts, footer, basename, filename):
         # slides) on this split - if so, it is a forgotten !split
         subsections = re.findall(r'\\subsection\{', code_free_part)
         if len(subsections) > 1:
-            print '*** error: more than one subsection in a slide (insert missing !split):'
-            print part
+            print('*** error: more than one subsection in a slide (insert missing !split):')
+            print(part)
             _abort()
 
         # Add text for this slide
@@ -5823,7 +5835,7 @@ def generate_beamer_slides(header, parts, footer, basename, filename):
     return slides
 
 def _usage_split_rst0():
-    print 'Usage: doconce split_rst complete_file.rst'
+    print('Usage: doconce split_rst complete_file.rst')
 
 def split_rst0():
     """
@@ -5896,16 +5908,16 @@ def split_rst0():
         f = open(filename, 'w')
         f.write(text)
         f.close()
-    print ' '.join(parts)
+    print(' '.join(parts))
 
 def _usage_split_rst():
-    print 'Usage: doconce split_rst mydoc'
-    print """Example:
+    print('Usage: doconce split_rst mydoc')
+    print("""Example:
 doconce sphinx_dir author="Kaare Dump" title="Short title" dirname=mydir mydoc
 doconce format sphinx mydoc
 doconce split_rst mydoc
 python automake_sphinx.py
-"""
+""")
 
 
 def split_rst():
@@ -5927,8 +5939,8 @@ def split_rst():
     header, parts, footer = get_header_parts_footer(filename, "rst")
     import pprint
     files = doconce_rst_split(parts, basename, filename)
-    print basename, 'split into'
-    print ' '.join(files)
+    print(basename, 'split into')
+    print(' '.join(files))
 
 
 def doconce_rst_split(parts, basename, filename):
@@ -5965,24 +5977,24 @@ def doconce_rst_split(parts, basename, filename):
             first_heading = m.group(1)
             if first_heading.startswith('='):
                 if re.search(r'^(%%+)$', text, flags=re.MULTILINE):
-                    print """
+                    print("""
 *** error: first heading in part %d is a section, but the part
     also contains a chapter.
-    !split must be moved to avoid such inconsistent reST headings""" % pn
+    !split must be moved to avoid such inconsistent reST headings""" % pn)
                     _abort()
             elif first_heading.startswith('-'):
                 if re.search(r'^(%%+|==+)$', text, flags=re.MULTILINE):
-                    print """
+                    print("""
 *** error: first heading in part %d is a subsection, but the part
     also contains a chapter or section.
-    !split must be moved to avoid such inconsistent reST headings""" % pn
+    !split must be moved to avoid such inconsistent reST headings""" % pn)
                     _abort()
             elif first_heading.startswith('~'):
                 if re.search(r'^(%%+|==+|--+)$', text, flags=re.MULTILINE):
-                    print """
+                    print("""
 *** error: first heading in part %d is a subsubsection, but the part
     also contains a chapter, section, or subsection.
-    !split must be moved to avoid such inconsistent reST headings""" % pn
+    !split must be moved to avoid such inconsistent reST headings""" % pn)
                     _abort()
 
         part_filename = _part_filename % (basename, pn) + '.rst'
@@ -6023,7 +6035,7 @@ def doconce_rst_split(parts, basename, filename):
     return generated_files
 
 def _usage_list_labels():
-    print 'Usage: doconce list_labels doconcefile.do.txt'
+    print('Usage: doconce list_labels doconcefile.do.txt')
 
 def list_labels():
     """
@@ -6060,7 +6072,7 @@ def list_labels():
                 if m:
                     heading = m.group(1).strip()
             if heading:
-                print '# section: ' + heading
+                print('# section: ' + heading)
 
             # Identify label
             if 'label{' in line:
@@ -6068,15 +6080,15 @@ def list_labels():
                 if m:
                     label = m.group(1).strip()
                 else:
-                    print 'Syntax error in line'
-                    print line
+                    print('Syntax error in line')
+                    print(line)
                     _abort()
-                print label
+                print(label)
                 labels.append(label)
 
 
 def _usage_teamod():
-    print 'Usage: doconce teamod name'
+    print('Usage: doconce teamod name')
 
 def teamod():
     if len(sys.argv) < 2:
@@ -6086,7 +6098,7 @@ def teamod():
     name = sys.argv[1]
     if os.path.isdir(name):
         os.rename(name, name + '.old~~')
-        print 'directory %s exists, renamed to %s.old~~' % (name, name)
+        print('directory %s exists, renamed to %s.old~~' % (name, name))
     os.mkdir(name)
     os.chdir(name)
     os.mkdir('fig-%s' % name)
@@ -6146,7 +6158,7 @@ A list with
 
 
 def _usage_assemble():
-    print 'Usage: doconce assemble master.do.txt'
+    print('Usage: doconce assemble master.do.txt')
 
 def assemble():
     # See 2DO and teamod.do.txt
@@ -6169,7 +6181,7 @@ def assemble():
     # Run analyzer...
 
 def _usage_analyzer():
-    print 'Usage: doconce analyzer complete_file.do.txt'
+    print('Usage: doconce analyzer complete_file.do.txt')
 
 def analyzer():
     """
@@ -6249,9 +6261,9 @@ def analyzer():
         movie_files = [filename for filename, options, captions in \
                        movie.findall(fstr)]
         code_files = code.findall(fstr)
-        print figure_files
+        print(figure_files)
         figure_dirs = [os.path.dirname(f) for f in figure_files] # no dir??
-        print figure_dirs
+        print(figure_dirs)
         dirs = [os.path.join(directory, figure_dir) \
                 for figure_dir in figure_dirs]
 
@@ -6260,11 +6272,11 @@ def analyzer():
 
 def old2new_format():
     if len(sys.argv) == 1:
-        print 'Usage: %s file1.do.txt file2.do.txt ...' % sys.argv[0]
+        print('Usage: %s file1.do.txt file2.do.txt ...' % sys.argv[0])
         sys.exit(1)
 
     for filename in sys.argv[1:]:
-        print 'Converting', filename
+        print('Converting', filename)
         _old2new(filename)
 
 def _old2new(filename):
@@ -6292,24 +6304,24 @@ def _old2new(filename):
         if lines[i].startswith('AUTHOR:'):
             # swith to "name at institution":
             if not ' at ' in lines[i]:
-                print 'Warning, file "%s": AUTHOR line needs "name at institution" syntax' % filename
+                print('Warning, file "%s": AUTHOR line needs "name at institution" syntax' % filename)
 
         if oldline != lines[i]:
             nchanges += 1
-            print 'Changing\n  ' + oldline + ' to\n  ' + lines[i]
+            print('Changing\n  ' + oldline + ' to\n  ' + lines[i])
 
-    print 'Performed %d changes in "%s"' % (nchanges, filename)
+    print('Performed %d changes in "%s"' % (nchanges, filename))
     f = open(filename, 'w')
     f.writelines(lines)
     f.close()
 
 def latex_header():
-    from doconce.doconce import INTRO
-    print INTRO['latex']
+    from .doconce.doconce import INTRO
+    print(INTRO['latex'])
 
 def latex_footer():
-    from doconce.doconce import OUTRO
-    print OUTRO['latex']
+    from .doconce.doconce import OUTRO
+    print(OUTRO['latex'])
 
 
 # -------------------- functions for spell checking ---------------------
@@ -6513,8 +6525,8 @@ def _grep_common_typos(text, filename, common_typos):
     for i, line in enumerate(text.splitlines()):
         for typo in common_typos:
             if re.search(typo, line):
-                print '\ntypo "%s" in line %d in file %s:\n' % \
-                      (typo, i+1, filename), line
+                print('\ntypo "%s" in line %d in file %s:\n' % \
+                      (typo, i+1, filename), line)
                 found = True
     if found:
         sys.exit(1)
@@ -6536,14 +6548,14 @@ def _strip_environments(text, environments, verbose=0):
             subparts = part.split(end)
             text += end.join(subparts[1:])
             if verbose > 1:
-                print '\n============ split %s <-> %s\ntext so far:' % (begin, end)
-                print text
-                print '\n============\nSkipped:'
-                print subparts[0]
+                print('\n============ split %s <-> %s\ntext so far:' % (begin, end))
+                print(text)
+                print('\n============\nSkipped:')
+                print(subparts[0])
         if verbose > 0:
-            print 'split away environments: %s %s\nnew text:\n' % (begin, end)
-            print text
-            print '\n=================='
+            print('split away environments: %s %s\nnew text:\n' % (begin, end))
+            print(text)
+            print('\n==================')
     return text
 
 def _do_regex_replacements(text, replacements, verbose=0):
@@ -6556,9 +6568,9 @@ def _do_regex_replacements(text, replacements, verbose=0):
             from_, to_, flags = item
             text = re.sub(from_, to_, text, flags=flags)
         if verbose > 0:
-            print '=================='
-            print 'regex substitution: %s -> %s\nnew text:' % (from_, to_)
-            print text
+            print('==================')
+            print('regex substitution: %s -> %s\nnew text:' % (from_, to_))
+            print(text)
     return text
 
 def _do_fixes_4MSWord(text):
@@ -6638,7 +6650,7 @@ def _spellcheck(filename, dictionaries=['.dict4spell.txt'], newdict=None,
     try:
         f = open(filename, 'r')
     except IOError:
-        print '\nfile %s does not exist!' % filename
+        print('\nfile %s does not exist!' % filename)
         _abort()
 
     text = f.read()
@@ -6676,12 +6688,12 @@ def _spellcheck(filename, dictionaries=['.dict4spell.txt'], newdict=None,
                 is_word = '_' not in word
 
             if is_word:
-                print "\ndouble words detected in %s (marked inside [...]):\n------------------------" % filename
-                print "%s[%s]%s\n------------------------" % \
+                print("\ndouble words detected in %s (marked inside [...]):\n------------------------" % filename)
+                print("%s[%s]%s\n------------------------" % \
                       (text[max(0,start+m.start()-offset):start+m.start()],
                        word,
                        text[start+m.end():min(start+m.end()+offset,
-                                               len(text)-1)])
+                                               len(text)-1)]))
                 found = True
             start += m.end()
         else:
@@ -6695,9 +6707,9 @@ def _spellcheck(filename, dictionaries=['.dict4spell.txt'], newdict=None,
     # Remove inline verbatim
     text = re.sub(r'`[^ ][^`]*?`', '', text)  # remove inline verbatim
     if verbose > 0:
-        print 'removal of quotes, inline verbatim, code and tex blocks\nnew text:\n'
-        print text
-        print '==================\n'
+        print('removal of quotes, inline verbatim, code and tex blocks\nnew text:\n')
+        print(text)
+        print('==================\n')
 
     # Continue with spell checking
 
@@ -6743,7 +6755,7 @@ def _spellcheck(filename, dictionaries=['.dict4spell.txt'], newdict=None,
             personal_dictionaries += f.readlines()
             f.close()
         else:
-            print 'Dictionary file %s does not exist.' % dictionary
+            print('Dictionary file %s does not exist.' % dictionary)
 
     personal_dictionaries = list(set(personal_dictionaries))
     misspellings = 'tmp_misspelled_' + filename + '~'
@@ -6758,7 +6770,7 @@ def _spellcheck(filename, dictionaries=['.dict4spell.txt'], newdict=None,
     f.close()
     words2 = list(set(words))  # remove multiple words
     if len(words2) > 0:             # do we have misspellings?
-        print '%d misspellings in %s' % (len(words2), filename)
+        print('%d misspellings in %s' % (len(words2), filename))
         if remove_multiplicity:
             f = open(misspellings, 'w')
             f.write(words2)
@@ -6802,22 +6814,22 @@ def _spellcheck_all(**kwargs):
             _spellcheck(filename, **kwargs)
     tmp_misspelled = glob.glob('tmp_misspelled*~')
     if len(tmp_misspelled) > 0:
-        print
+        print()
         if len(sys.argv[1:]) == 1:
-            print 'See misspellings.txt~ for all misspelled words found.'
+            print('See misspellings.txt~ for all misspelled words found.')
         else:
             for name in tmp_misspelled:
-                print 'See', name, 'for misspellings in', name.replace('tmp_misspelled_', '')[:-1]
-        print 'Search tmp_stripped_*.do.txt for the misspellings'
+                print('See', name, 'for misspellings in', name.replace('tmp_misspelled_', '')[:-1])
+        print('Search tmp_stripped_*.do.txt for the misspellings')
         dictfile = kwargs.get('dictionary', '.dict4spell.txt')
-        print 'When all misspellings are acceptable, cp new_dictionary.txt~',\
-              dictfile, '\n'
+        print('When all misspellings are acceptable, cp new_dictionary.txt~',\
+              dictfile, '\n')
         sys.exit(1)
     else:
         sys.exit(0)
 
 def _usage_spellcheck():
-    print """
+    print("""
 doconce spellcheck file1.do.txt file2.do.txt ...  # use .dict4spell.txt
 doconce spellcheck -d .mydict.txt file1.do.txt file2.do.txt ...
 
@@ -6905,7 +6917,7 @@ in ``tmp_stripped_*`` files:
 
 execfile is applied to .strip to execute the definition of the lists.
 
-"""
+""")
 
 
 def spellcheck():
@@ -6933,9 +6945,9 @@ def spellcheck():
                     dictionaries=dictionary, verbose=verbose)
 
 def _usage_ref_external():
-    print 'doconce ref_external dofile [pubfile --skip_chapter]'
-    print 'Must give pubfile if no BIBFILE in dofile.do.txt'
-    print '--skip_chapter avoids substitution of Chapter ref{} -> refch[Chapter ...][][].'
+    print('doconce ref_external dofile [pubfile --skip_chapter]')
+    print('Must give pubfile if no BIBFILE in dofile.do.txt')
+    print('--skip_chapter avoids substitution of Chapter ref{} -> refch[Chapter ...][][].')
 
 def ref_external():
     """
@@ -6962,8 +6974,8 @@ def ref_external():
     if m:
         external_docs = [s.strip() for s in m.group(1).split(',')]
     else:
-        print '*** error: no # Externaldocuments: file1, file2, ... in', basename + '.do.txt'
-        print '    cannot get info about external documents and their labels!'
+        print('*** error: no # Externaldocuments: file1, file2, ... in', basename + '.do.txt')
+        print('    cannot get info about external documents and their labels!')
         _abort()
     m = re.search('^BIBFILE:\s*(.+)', topfilestr, re.MULTILINE)
     if m:
@@ -6972,9 +6984,9 @@ def ref_external():
         if len(sys.argv) >= 3:
             pubfile = sys.argv[2]
         else:
-            print '*** error: no BIBFILE: file.pub, missing publish file on the command line!'
+            print('*** error: no BIBFILE: file.pub, missing publish file on the command line!')
             _abort()
-    print '    working with publish file', pubfile
+    print('    working with publish file', pubfile)
     import publish
     # Note: we have to operate publish in the directory
     # where pubfile resides
@@ -6989,7 +7001,7 @@ def ref_external():
     def process_external_doc(extdoc_basename):
         topfile = extdoc_basename + '.do.txt'
         if not os.path.isfile(topfile):
-            print '*** error: external document "%s" does not exist' % topfile
+            print('*** error: external document "%s" does not exist' % topfile)
             _abort()
         f = open(topfile, 'r')
         text = f.read()
@@ -6997,7 +7009,7 @@ def ref_external():
         if m:
             title = m.group(1).strip()
         else:
-            print '*** error: no TITLE: ... in "%s"' % topfile
+            print('*** error: no TITLE: ... in "%s"' % topfile)
             _abort()
         found = False
         key = None
@@ -7006,15 +7018,15 @@ def ref_external():
             if pub['title'].lower() == title.lower():
                 key = pub.get('key', None)
                 url = pub.get('url', None)
-                print '       title:', title
-                print '       url:', url
-                print '       key:', key
+                print('       title:', title)
+                print('       url:', url)
+                print('       key:', key)
                 found = True
                 break
         if not found and extdoc_basename != basename:
-            print '*** warning: could not find the document'
-            print '   ', title
-            print '    in the publish database %s' % pubfile
+            print('*** warning: could not find the document')
+            print('   ', title)
+            print('    in the publish database %s' % pubfile)
 
         # Try to load the full doconce file as the result of mako,
         # or as the result of preprocess, or just extdoc_basename.do.txt
@@ -7031,11 +7043,11 @@ def ref_external():
                 # Check that there are no includes:
                 m = re.search(r'^#\s+#include', text, flags=re.MULTILINE)
                 if m:
-                    print '*** error: doconce format is not run on %s' % topfile
-                    print '    cannot proceed...'
+                    print('*** error: doconce format is not run on %s' % topfile)
+                    print('    cannot proceed...')
                     _abort()
 
-        print '    ...processing', fullfile
+        print('    ...processing', fullfile)
         f = open(fullfile, 'r')
         text = f.read()
         f.close()
@@ -7097,9 +7109,9 @@ def ref_external():
     # get additional info about all references
     for label in mylabels:
         if label in refs2extdoc:
-            print '*** error: ref{%s} in %s was found as' % (label, basename)
-            print '    label{%s} in %s and %s' % \
-                  (label, basename, refs2extdoc[label][0])
+            print('*** error: ref{%s} in %s was found as' % (label, basename))
+            print('    label{%s} in %s and %s' % \
+                  (label, basename, refs2extdoc[label][0]))
             _abort()
 
     # Substitute all external references by ref[][][]
@@ -7107,8 +7119,8 @@ def ref_external():
     scriptname2 = 'tmp_grep_references.sh'
     f = open(scriptname, 'w')
     f2 = open(scriptname2, 'w')
-    print 'substitution script:', scriptname
-    print 'grep script (for context of each substitution):', scriptname2
+    print('substitution script:', scriptname)
+    print('grep script (for context of each substitution):', scriptname2)
     dofiles = basename[5:] + '.do.txt' if basename.startswith('main_') else basename + '.do.txt'
     f.write('files="%s"  # files to which substitutions apply\n\n' % dofiles)
     f2.write('files="%s"  # files to which substitutions apply\n\nnlines=6  # no of context lines for each matched line' % dofiles)
@@ -7209,13 +7221,13 @@ def ref_external():
     f.close()
 
 def _usage_latex_problems():
-    print 'doconce latex_problems mydoc.log [overfull-hbox-limit --texcode]'
-    print """
+    print('doconce latex_problems mydoc.log [overfull-hbox-limit --texcode]')
+    print("""
 Interpret the .log file and write out latex problems related to
 undefined references, multiply defined labels, and overfull hboxes.
 The lower limit for overfull hboxes can be specified as an integer.
 --texcode causes the problematic lines in overfull hboxes to be printed.
-"""
+""")
 
 def latex_problems():
     if len(sys.argv) < 2:
@@ -7261,14 +7273,14 @@ def latex_problems():
     problems = False
     if multiply_defined_labels:
         problems = True
-        print '\nMultiply defined labels:'
+        print('\nMultiply defined labels:')
         for label in multiply_defined_labels:
-            print '    ', label
+            print('    ', label)
     if undefined_references:
         problems = True
-        print '\nUndefined references:'
+        print('\nUndefined references:')
         for ref, page in undefined_references:
-            print '    ', ref, 'on page', page
+            print('    ', ref, 'on page', page)
     if overfull_hboxes:
         texcode = '--texcode' in sys.argv
         if texcode:
@@ -7277,25 +7289,25 @@ def latex_problems():
             texfile = f.readlines()
             f.close()
         problems = True
-        print "\nOverfull hbox'es:"
+        print("\nOverfull hbox'es:")
         for npt, at_lines in overfull_hboxes:
             if float(npt) > overfull_hbox_limit and npt not in ok_overfull_hboxes:
-                print '    ', npt, 'lines', at_lines
+                print('    ', npt, 'lines', at_lines)
                 if texcode:
                     line_range = [int(line)-1 for line in at_lines.split('--')]
                     if line_range[1] - line_range[0] < 4 and r'\end' in texfile[line_range[1]]:
                         # Print more surroundings above
-                        print '\n*** printing 6 lines above problem line:'
-                        print ''.join(texfile[line_range[0]-6:line_range[1]+1])
+                        print('\n*** printing 6 lines above problem line:')
+                        print(''.join(texfile[line_range[0]-6:line_range[1]+1]))
                     else:
-                        print '\n', ''.join(texfile[line_range[0]:line_range[1]+1])
+                        print('\n', ''.join(texfile[line_range[0]:line_range[1]+1]))
 
     if not problems:
-        print 'no serious LaTeX problems found in %s!' % filename
+        print('no serious LaTeX problems found in %s!' % filename)
 
 
 def _usage_grep():
-    print 'doconce grep FIGURE|MOVIE|CODE doconce-file'
+    print('doconce grep FIGURE|MOVIE|CODE doconce-file')
 
 def grep():
     if len(sys.argv) < 3:
@@ -7325,14 +7337,14 @@ def grep():
             pattern = '^@@@CODE +(.+?)\s+'
             filenames += re.findall(pattern, filestr, re.MULTILINE)
         else:
-            print '*** error: cannot grep', file_tp, '(not implemented)'
+            print('*** error: cannot grep', file_tp, '(not implemented)')
     filenames = list(set(filenames))  # remove multiple filenames
-    print ' '.join(filenames)
+    print(' '.join(filenames))
 
 def _usage_capitalize():
-    print 'doconce capitalize [-d file_with_cap_words] doconce-file'
-    print 'list of capitalized words can also be in .dict4cap.txt'
-    print '(typically, Python, Unix, etc. must be capitalized)'
+    print('doconce capitalize [-d file_with_cap_words] doconce-file')
+    print('list of capitalized words can also be in .dict4cap.txt')
+    print('(typically, Python, Unix, etc. must be capitalized)')
 
 def capitalize():
     if len(sys.argv) >= 2 and sys.argv[1] == '-d':
@@ -7434,9 +7446,9 @@ def capitalize():
     f.close()
     for old, new in old2new:
         if old != new:
-            print old
-            print new
-            print
+            print(old)
+            print(new)
+            print()
 
 def _capitalize(filestr, cap_words, cap_words_fix):
     pattern1 = r'^\s*(={3,9})(.+?)(={3,9})'  # sections
@@ -7513,10 +7525,10 @@ def _capitalize(filestr, cap_words, cap_words_fix):
 
 
 def _usage_md2html():
-    print 'Usage: doconce md2html doconce-file'
-    print 'Make HTML from pandoc-exteded Markdown'
-    print '(.html file from .md pandoc file)'
-    print 'The purpose is to fix the HTML code with full MathJax support.'
+    print('Usage: doconce md2html doconce-file')
+    print('Make HTML from pandoc-exteded Markdown')
+    print('(.html file from .md pandoc file)')
+    print('The purpose is to fix the HTML code with full MathJax support.')
 
 def md2html():
     """
@@ -7544,13 +7556,13 @@ def md2html():
     basename = filename[:-3]
     cmd = 'pandoc -f markdown -t html --mathjax -s -o %s.html %s.md' % \
           (basename, basename)
-    print cmd
+    print(cmd)
     try:
         output = subprocess.check_output(cmd, shell=True,
                                          stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as e:
-        print 'could not run\n', cmd
-        print output
+        print('could not run\n', cmd)
+        print(output)
         sys.exit(1)
     f = open('%s.html' % basename, 'r')
     text = f.read()
@@ -7574,14 +7586,14 @@ MathJax.Hub.Config({
     f = open('%s.html' % basename, 'w')
     f.write(text)
     f.close()
-    print 'output in %s.html' % basename
+    print('output in %s.html' % basename)
 
 
 def _usage_md2latex():
-    print 'Usage: doconce md2latex doconce-file'
-    print 'Make LaTeX from pandoc-exteded Markdown'
-    print '(.tex file from .md file).'
-    print 'The purpose is to fix the LaTeX code so it compiles.'
+    print('Usage: doconce md2latex doconce-file')
+    print('Make LaTeX from pandoc-exteded Markdown')
+    print('(.tex file from .md file).')
+    print('The purpose is to fix the LaTeX code so it compiles.')
 
 def md2latex():
     """
@@ -7603,13 +7615,13 @@ def md2latex():
     basename = filename[:-3]
     cmd = 'pandoc -f markdown -t latex -s -o %s.tex %s.md' % \
           (basename, basename)
-    print cmd
+    print(cmd)
     try:
         output = subprocess.check_output(cmd, shell=True,
                                          stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as e:
-        print 'could not run\n', cmd
-        print e.output
+        print('could not run\n', cmd)
+        print(e.output)
         sys.exit(1)
     f = open('%s.tex' % basename, 'r')
     text = f.read()
@@ -7619,7 +7631,7 @@ def md2latex():
     f = open('%s.tex' % basename, 'w')
     f.write(text)
     f.close()
-    print 'output in %s.tex' % basename
+    print('output in %s.tex' % basename)
 
 
 # ----------------------- functions for insertdocstr -----------------------
@@ -7663,7 +7675,7 @@ def insertdocstr():
         format = sys.argv[1]
         root = sys.argv[2]
     except:
-        print 'Usage: doconce insertdocstr format root [preprocessor options]'
+        print('Usage: doconce insertdocstr format root [preprocessor options]')
         sys.exit(1)
 
     global doconce_program
@@ -7674,14 +7686,14 @@ def insertdocstr():
     # alternative: use sys.argv[3] argument to tell where to find doconce
     # can then run "bin/doconce insertdocstr bin" from setup.py
 
-    print '\n----- doconce insertdocstr %s %s\nFind and transform doconce files (.do.txt) ...' % (format, root)
+    print('\n----- doconce insertdocstr %s %s\nFind and transform doconce files (.do.txt) ...' % (format, root))
     arg = format
     os.path.walk(root, _walker_doconce, arg)
 
-    print 'Find and preprocess .p.py files (insert doc strings etc.)...'
+    print('Find and preprocess .p.py files (insert doc strings etc.)...')
     arg = ' '.join(sys.argv[3:])  # options for preprocessor
     os.path.walk(root, _walker_include, arg)
-    print '----- end of doconce insertdocstr -----\n'
+    print('----- end of doconce insertdocstr -----\n')
 
 
 
@@ -7713,12 +7725,12 @@ def _run_doconce(filename_doconce, format):
     """
     if filename_doconce.startswith('__'):
         # old preprocessed file from aborted doconce execution
-        print 'skipped', filename_doconce
+        print('skipped', filename_doconce)
         return
 
     global doconce_program # set elsewhere
     cmd = '%s format %s %s' % (doconce_program, format, filename_doconce)
-    print 'run', cmd
+    print('run', cmd)
     try:
         output = subprocess.check_output(cmd, shell=True,
                                          stderr=subprocess.STDOUT)
@@ -7729,7 +7741,7 @@ def _run_doconce(filename_doconce, format):
     root, ext = os.path.splitext(out_filename)
     new_filename = root + '.dst.txt'
     os.rename(out_filename, new_filename)
-    print '(renamed %s to %s for possible inclusion in doc strings)\n' % (out_filename, new_filename)
+    print('(renamed %s to %s for possible inclusion in doc strings)\n' % (out_filename, new_filename))
 
 def _walker_doconce(arg, dir, files):
     format = arg
@@ -7744,13 +7756,13 @@ def _walker_doconce(arg, dir, files):
 def _run_preprocess4includes(filename_dotp_py, options=''):
     pyfile = filename_dotp_py[:-5] + '.py'
     cmd = 'preprocess %s %s > %s' % (options, filename_dotp_py, pyfile)
-    print 'run', cmd
+    print('run', cmd)
     try:
         output = subprocess.check_output(cmd, shell=True,
                                          stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as e:
-        raise OSError, 'Could not run\n%s\nin %s\n%s\n\n\n' % \
-              (cmd, os.getcwd(), e.output)
+        raise OSError('Could not run\n%s\nin %s\n%s\n\n\n' % \
+              (cmd, os.getcwd(), e.output))
 
 def _walker_include(arg, dir, files):
     options = arg
@@ -7851,13 +7863,13 @@ def _latex2doconce(filestr):
         try:
             user_subst = subst
             user_replace = replace
-        except NameError, e:
-            print fixfile, 'does not contain subst and replace lists'
-            print e
+        except NameError as e:
+            print(fixfile, 'does not contain subst and replace lists')
+            print(e)
             sys.exit(1)
-        except Exception, e:
-            print fixfile, 'has errors'
-            print e
+        except Exception as e:
+            print(fixfile, 'has errors')
+            print(e)
             sys.exit(1)
 
     # cf. doconce.latex.fix_latex_command_regex to see how important
@@ -7947,8 +7959,8 @@ def _latex2doconce(filestr):
                 filestr = cpattern.sub(replacement, filestr)
             else:
                 pass
-    except Exception, e:
-        print 'pattern: %s, replacement: %s' % (pattern, replacement)
+    except Exception as e:
+        print('pattern: %s, replacement: %s' % (pattern, replacement))
         raise e
 
     replace = [
@@ -8088,8 +8100,8 @@ def _latex2doconce(filestr):
 
     # Find subfigures (problems)
     if filestr.count('\\subfigure{') > 0:
-        print '\nPROBLEM: found \\subfigure{...} - should be changed (combine individual'
-        print '      figure files into a single file; now subfigures are just ignored!)\n'
+        print('\nPROBLEM: found \\subfigure{...} - should be changed (combine individual')
+        print('      figure files into a single file; now subfigures are just ignored!)\n')
 
     # Figures: assumptions are that subfigure is not used and that the label
     # sits inside the caption. Also, width should be a fraction of
@@ -8327,18 +8339,18 @@ def _latex2doconce(filestr):
                     # (sometimes 1st column may have no header)
                     s = list(separator1)
                     for j in range(len(align_headings)):
-                        s[len(s)-1-max_column_width/2 - j*max_column_width] = align_headings[len(align_headings)-1-j]
+                        s[len(s)-1-old_div(max_column_width,2) - j*max_column_width] = align_headings[len(align_headings)-1-j]
                     separator1 = ''.join(s)
                 if align is not None:
                     # As many chars in align as there are columns
                     s = list(separator2)
                     for j in range(len(align)):
                         try:
-                            s[max_column_width/2 + j*max_column_width] = align[j]
+                            s[old_div(max_column_width,2) + j*max_column_width] = align[j]
                         except IndexError:
-                            print '_ERROR:_ something went wrong when translating a table:'
+                            print('_ERROR:_ something went wrong when translating a table:')
                             for line in table_lines:
-                                print line
+                                print(line)
                     separator2 = ''.join(s)
                 column_format = ' %%-%ds ' % (max_column_width-2)
                 for j in range(len(table_lines)):
@@ -8380,14 +8392,14 @@ def _latex2doconce(filestr):
                       r'(_PROBLEM: external ref_) ref{%s}' % ref)
     '''
     for ref in pagerefs:
-        print 'pageref{%s} should be rewritten' % ref
+        print('pageref{%s} should be rewritten' % ref)
         filestr = filestr.replace(r'\pageref{%s}' % ref,
             r'(_PROBLEM: pageref_) \pageref{%s}' % ref)
         problems = True
 
-    print '\n## search for CHECK to see if auto editing was correct\n'
+    print('\n## search for CHECK to see if auto editing was correct\n')
     if problems:
-        print '\n## search for PROBLEM: to see need for manual adjustments\n\n\n'
+        print('\n## search for PROBLEM: to see need for manual adjustments\n\n\n')
     filestr = filestr.replace(r'\label{', 'label{')  # done above
     filestr = filestr.replace(r'\ref{', 'ref{')
     filestr = filestr.replace(r'\cite{', 'cite{')
@@ -8442,21 +8454,21 @@ def latex2doconce():
     by files combined to a single file, avoid footnotes, index inside
     paragraphs, do not start code blocks with indentation, ...
     """
-    print """# #ifdef LATEX2DOCONCE
+    print("""# #ifdef LATEX2DOCONCE
 This is the result of the doconce latex2doconce program.
 The translation from LaTeX is just a helper. The text must
 be carefully examined! (Be prepared that some text might also
 be lost in the translation - in seldom cases.)
-"""
+""")
     filename = sys.argv[1]
     f = open(filename, 'r')
     filestr = f.read()
     f.close()
     filestr = _latex2doconce(filestr)
 
-    print '# #endif'   # end of intro with warnings etc.
+    print('# #endif')   # end of intro with warnings etc.
 
-    print filestr  # final output
+    print(filestr)  # final output
 
 
 def html2doconce():
@@ -8464,12 +8476,12 @@ def html2doconce():
     Apply transformations to an html file to help translate the
     document into DocOnce format.
     """
-    print """# #ifdef HTML2DOCONCE
+    print("""# #ifdef HTML2DOCONCE
 This is the result of the doconce htmldoconce program.
 The translation from HTML is just a helper. The text must
 be carefully examined! (Be prepared that some text might also
 be lost in the translation - in seldom cases.)
-"""
+""")
 
     filename = sys.argv[1]
     f = open(filename, 'r')
@@ -8477,9 +8489,9 @@ be lost in the translation - in seldom cases.)
     f.close()
     filestr = _html2doconce(filestr)
 
-    print '# #endif'   # end of intro with warnings etc.
+    print('# #endif')   # end of intro with warnings etc.
 
-    print filestr  # final output to stdout
+    print(filestr)  # final output to stdout
 
 
 def _html2doconce(filestr):
@@ -8515,15 +8527,15 @@ def _html2doconce(filestr):
     # All lists become bullet lists, read line by line and use a stack
     # to improve this
     if '<ol>' in filestr:
-        print '*** warning: enumerated lists become bullet lists'
+        print('*** warning: enumerated lists become bullet lists')
     filestr = re.sub(r'<ol>', '\n', filestr)
     filestr = re.sub(r'</ol>', '\n', filestr)
     filestr = re.sub(r'<li>', '  * ', filestr)
 
     if '<table' in filestr:
-        print '*** warning: html2doconce cannot handle tables.'
-        print '    Recommendation: edit manually to CSV format and run'
-        print '    doconce csv2table command to create table.'
+        print('*** warning: html2doconce cannot handle tables.')
+        print('    Recommendation: edit manually to CSV format and run')
+        print('    doconce csv2table command to create table.')
 
     return filestr
 
@@ -8597,25 +8609,25 @@ def latex_dislikes():
                 if envir in begin_likes:
                     pass # fine!
                 elif envir in begin_ok:
-                    print """
+                    print("""
 Found \\begin{%s}, which can be handled, but it is
-recommended to avoid this construction.""" % envir
+recommended to avoid this construction.""" % envir)
                 else:
-                    print """
+                    print("""
 Found \\begin{%s}, which will not carry over to DocOnce
-and other formats.""" % envir
+and other formats.""" % envir)
                     # Could have message here (begin_messages) that
                     # guide rewrites, e.g., lstlisting etc.
-                print line + '\n'
+                print(line + '\n')
 
         for regex, message in dislikes:
             if re.search(regex, line):
-                print message
-                print line + '\n'
+                print(message)
+                print(line + '\n')
 
 def _usage_ipynb2doconce():
-    print 'doconce ipynb2doconce notebook.ipynb [--cell_delimiter]'
-    print 'translate IPython/Jupyter notebooks to doconce'
+    print('doconce ipynb2doconce notebook.ipynb [--cell_delimiter]')
+    print('translate IPython/Jupyter notebooks to doconce')
 
 def ipynb2doconce():
     if len(sys.argv) < 2:
@@ -8625,7 +8637,7 @@ def ipynb2doconce():
     cell_delimiter = '--cell_delimiter' in sys.argv
     filename = sys.argv[1]
     if not os.path.isfile(filename):
-        print '*** error: no file "%s" found' % filename
+        print('*** error: no file "%s" found' % filename)
         sys.exit(1)
     f = open(filename, 'r')
     jsonstring = f.read()
@@ -8638,8 +8650,8 @@ def ipynb2doconce():
         try:
             from IPython.nbformat.reader import reads
         except ImportError:
-            print '*** error: cannot do import nbformat or IPython.nbformat'
-            print '    make sure IPython notebook or Jupyter is installed correctly'
+            print('*** error: cannot do import nbformat or IPython.nbformat')
+            print('    make sure IPython notebook or Jupyter is installed correctly')
             _abort()
 
     nb = reads(jsonstring)
@@ -8647,14 +8659,14 @@ def ipynb2doconce():
 
     # checking if we have modern enough ipynb format
     if nb['nbformat'] < 4:
-        print """*** error: ipynb file format is too old (at least v4 needed).
+        print("""*** error: ipynb file format is too old (at least v4 needed).
 Please, upgrade format of your ipynb-file using Jupyter (just open and save
 the file) and then try again.
-"""
+""")
         _abort()
 
     dostr_list = []
-    from doconce import markdown2doconce
+    from .doconce import markdown2doconce
     cell_type_prev = None
     for cell in nb['cells']:
         if cell_delimiter and cell['cell_type'] != cell_type_prev:
@@ -8698,7 +8710,7 @@ the file) and then try again.
         f = open(filename, 'w')
     f.write(dostr)
     f.close()
-    print 'output in', filename
+    print('output in', filename)
 
 # ---- Attempt to make a pygments syntax highlighter for DocOnce ----
 try:
@@ -8712,7 +8724,7 @@ try:
     from pygments.styles import get_all_styles
 except ImportError:
     pygm = None
-    print 'pygments is not installed'
+    print('pygments is not installed')
     _abort()
 
 class DocOnceLexer(RegexLexer):
@@ -8950,7 +8962,7 @@ class DocOnceLexer(RegexLexer):
         True
 
 def _usage_pygmentize():
-    print 'Usage: doconce pygmentize doconce-file [pygments style]'
+    print('Usage: doconce pygmentize doconce-file [pygments style]')
 
 def pygmentize():
     """
@@ -8976,11 +8988,11 @@ def pygmentize():
     formatter = HtmlFormatter(noclasses=True, style=pygm_style)
     text = highlight(text, lexer, formatter)
     f = open(filename + '.html', 'w');  f.write(text);  f.close()
-    print 'pygmentized doconce code written to %s.html' % filename
+    print('pygmentized doconce code written to %s.html' % filename)
 
 def _usage_makefile():
-    print 'Usage:   doconce makefile doconce-file [html pdflatex latex sphinx gwiki pandoc ipynb deck reveal beamer ...]'
-    print """Example: doconce makefile mydoc.do.txt html sphinx'
+    print('Usage:   doconce makefile doconce-file [html pdflatex latex sphinx gwiki pandoc ipynb deck reveal beamer ...]')
+    print("""Example: doconce makefile mydoc.do.txt html sphinx'
 
 A script make.py is generated with the basic steps for running a
 spellcheck on .do.txt files followed by commands for producing
@@ -8993,7 +9005,7 @@ to the various formats.
 
 make.py autogenerates a unix shell script with all commands: you may
 use this shell script instead of make.py.
-"""
+""")
 
 def makefile():
     """Generate a generic (Python) makefile for compiling doconce files."""
@@ -9476,17 +9488,17 @@ if __name__ == '__main__':
     main()
 """)
     make.close()
-    print 'generated make.py for compiling %s.do.txt' % dofile
-    print 'make.py is basically a template: edit to set the desired options'
-    print '\n*** warning: the generated make.py script is experimental\n    and tested to a very little extent! (latex, html, sphinx are tested)'
+    print('generated make.py for compiling %s.do.txt' % dofile)
+    print('make.py is basically a template: edit to set the desired options')
+    print('\n*** warning: the generated make.py script is experimental\n    and tested to a very little extent! (latex, html, sphinx are tested)')
 
 
 def _usage_fix_bibtex4publish():
-    print 'Usage: doconce fix_bibtex4publish fil1e.bib file2.bib ...'
-    print """
+    print('Usage: doconce fix_bibtex4publish fil1e.bib file2.bib ...')
+    print("""
 Fix a bibtex file so that the values are enclosed by braces (only)
 and publish can import the data.
-"""
+""")
 
 def fix_bibtex4publish():
     """Edit BibTeX files so that publish can import them."""
@@ -9497,16 +9509,16 @@ def fix_bibtex4publish():
     bibfiles = sys.argv[1:]
     for bibfile in bibfiles:
         if not bibfile.endswith('.bib'):
-            print bibfile, 'is not a BibTeX file'
+            print(bibfile, 'is not a BibTeX file')
             _abort()
         shutil.copy(bibfile, bibfile + '.old~~')
         f = open(bibfile, 'r')
         lines = f.readlines()
         f.close()
-        print '\n*** working with', bibfile, '\n'
+        print('\n*** working with', bibfile, '\n')
 
         for line in lines:
-            print line
+            print(line)
         keys = []
         for i in range(len(lines)):
             # Classification line? Fix to lower case publication type
@@ -9515,7 +9527,7 @@ def fix_bibtex4publish():
                 if m:
                     pub_type = m.group(1)
                     key = m.group(2)
-                    print '\n--- found %s (key %s)\n' % (pub_type, key)
+                    print('\n--- found %s (key %s)\n' % (pub_type, key))
                     pub_type = pub_type.lower()
                     if pub_type == 'incollection':
                         pub_type = 'inproceedings'
@@ -9528,7 +9540,7 @@ def fix_bibtex4publish():
                 variable = old_variable.lower().strip()
                 if len(words) > 2:
                     # A = in the value..
-                    print words
+                    print(words)
                     value = '='.join(words[1:]).strip()
                 else:
                     value = words[1].strip()
@@ -9550,9 +9562,9 @@ def fix_bibtex4publish():
                     fixed = True
                 lines[i] = '%-15s = %s,\n' % (variable, value)
                 if fixed:
-                    print '%s = %s' % (old_variable, old_value)
-                    print '...fixed to...'
-                    print '%-15s = %s\n' % (variable, value)
+                    print('%s = %s' % (old_variable, old_value))
+                    print('...fixed to...')
+                    print('%-15s = %s\n' % (variable, value))
             elif lines[i].strip() == '':
                 pass # ok
             elif lines[i].strip() == '}':
@@ -9563,9 +9575,9 @@ def fix_bibtex4publish():
                 # Loose sentence, this one should be glued with the
                 # former one
                 # NOT IMPLEMENTED
-                print '*** error: broken line'
-                print lines[i]
-                print 'Glue with previous line!'
+                print('*** error: broken line')
+                print(lines[i])
+                print('Glue with previous line!')
                 _abort()
 
         f = open(bibfile, 'w')
@@ -9573,7 +9585,7 @@ def fix_bibtex4publish():
         f.close()
 
 def _usage_list_fig_src_files():
-    print 'Usage: doconce list_fig_src_files *.do.txt'
+    print('Usage: doconce list_fig_src_files *.do.txt')
 
 def list_fig_src_files():
     """
@@ -9585,7 +9597,7 @@ def list_fig_src_files():
         _usage_list_fig_src_files()
         sys.exit(0)
 
-    from common import INLINE_TAGS
+    from .common import INLINE_TAGS
     code_pattern = '^@@@CODE +([^ ]+)'
     figs = []
     movs = []
@@ -9598,15 +9610,15 @@ def list_fig_src_files():
                  re.findall(INLINE_TAGS['movie'], text, flags=re.MULTILINE)]
         cods += re.findall(code_pattern, text, flags=re.MULTILINE)
     if figs:
-        print '\n'.join(figs)
+        print('\n'.join(figs))
     if movs:
-        print '\n'.join(movs)
+        print('\n'.join(movs))
     if cods:
-        print '\n'.join(cods)
+        print('\n'.join(cods))
 
 
 def _usage_csv2table():
-    print 'Usage: doconce csv2table somefile.csv [--headings=clr --columns=rrl --delimiter=;] > outfile'
+    print('Usage: doconce csv2table somefile.csv [--headings=clr --columns=rrl --delimiter=;] > outfile')
 
 def csv2table():
     """Convert a csv file to a DocOnce table."""
@@ -9648,13 +9660,13 @@ def csv2table():
         if arg.startswith('--headings='):
             align_headings = list(arg.split('=')[1])
             if len(align_headings) != num_columns:
-                print '*** error: %s has wrong no of columns (should be %d)' % \
-                      (arg, num_columns)
+                print('*** error: %s has wrong no of columns (should be %d)' % \
+                      (arg, num_columns))
         if arg.startswith('--columns='):
             align_columns = list(arg.split('=')[1])
             if len(align_columns) != num_columns:
-                print '*** error: %s has wrong no of columns (should be %d)' % \
-                      (arg, num_columns)
+                print('*** error: %s has wrong no of columns (should be %d)' % \
+                      (arg, num_columns))
 
 
     # Construct doconce table
@@ -9665,12 +9677,12 @@ def csv2table():
 
     s = list(separator1)
     for j in range(num_columns):
-        s[max_column_width/2 + 1 + j*(max_column_width+3)] = align_headings[j]
+        s[old_div(max_column_width,2) + 1 + j*(max_column_width+3)] = align_headings[j]
     separator1 = ''.join(s)
 
     s = list(separator2)
     for j in range(num_columns):
-        s[max_column_width/2 + 1 + j*(max_column_width+3)] = align_columns[j]
+        s[old_div(max_column_width,2) + 1 + j*(max_column_width+3)] = align_columns[j]
     separator2 = ''.join(s)
 
     column_format = ' %%-%ds ' % max_column_width
@@ -9680,7 +9692,7 @@ def csv2table():
     text = '\n\n' + separator1 + '\n' + table[0] + '\n' + \
            separator2 + '\n' + '\n'.join(table[1:]) + \
            '\n' + separator0 + '\n\n'
-    print text
+    print(text)
 
 
 # ------------ diff two files ----------------
@@ -9696,18 +9708,18 @@ _diff_programs = {
     }
 
 def _missing_diff_program(program_name):
-    print program_name, 'is not installed.'
-    print 'see', _diff_programs[program_name][0]
+    print(program_name, 'is not installed.')
+    print('see', _diff_programs[program_name][0])
     if not _diff_programs[program_name][1].startswith('not in'):
-        print 'Ubuntu/Debian Linux: sudo apt-get install', \
-              _diff_programs[program_name][1]
+        print('Ubuntu/Debian Linux: sudo apt-get install', \
+              _diff_programs[program_name][1])
     sys.exit(1)
 
 def _usage_diff():
-    print 'Usage: doconce diff oldfile newfile [diffprog]'
-    print 'diffprogram may be difflib (default),'
-    print 'pdiff, diff, diffuse, kdiff3, xxdiff, meld, latexdiff'
-    print 'Output in diff.*'
+    print('Usage: doconce diff oldfile newfile [diffprog]')
+    print('diffprogram may be difflib (default),')
+    print('pdiff, diff, diffuse, kdiff3, xxdiff, meld, latexdiff')
+    print('Output in diff.*')
 
 def diff():
     """Find differences between two files."""
@@ -9726,8 +9738,8 @@ def diff():
     if diffprog == 'difflib':
         diffing_files = pydiff(file1, file2)
         if diffing_files:
-            print 'differences found, see ', \
-                  ','.join([name + '.html|.txt' for name in diffing_files])
+            print('differences found, see ', \
+                  ','.join([name + '.html|.txt' for name in diffing_files]))
 
     elif diffprog == 'latexdiff':
         if which('latexdiff'):
@@ -9757,10 +9769,10 @@ def pydiff(files1, files2, n=3, prefix_diff_files='tmp_diff_'):
     for fromfile, tofile in zip(files1, files2):
 
         if not os.path.isfile(fromfile):
-            print fromfile, 'does not exist'
+            print(fromfile, 'does not exist')
             _abort()
         if not os.path.isfile(tofile):
-            print tofile, 'does not exist'
+            print(tofile, 'does not exist')
             _abort()
 
         fromdate = time.ctime(os.stat(fromfile).st_mtime)
@@ -9799,7 +9811,7 @@ def pydiff(files1, files2, n=3, prefix_diff_files='tmp_diff_'):
 def check_diff(diff_file):
     size = os.path.getsize(diff_file)
     if size > 4:
-        print 'diff in', diff_file
+        print('diff in', diff_file)
     else:
         os.remove(diff_file)
 
@@ -9835,7 +9847,7 @@ def latexdiff(files1, files2):
         failure = os.system('pdflatex %s' % diff_file)
         size = os.path.getsize(diff_file)
         if size > 4:
-            print 'output in', diff_file[:-3] + 'pdf'
+            print('output in', diff_file[:-3] + 'pdf')
 
 
 def diff_files(files1, files2, program='diff'):
@@ -9871,13 +9883,13 @@ def diff_files(files1, files2, program='diff'):
                        (diff_file, diff_file))
             else:
                 _missing_diff_program(program)
-            print 'diff in %s.pdf' % diff_file
+            print('diff in %s.pdf' % diff_file)
         else:
-            print program, 'not supported'
+            print(program, 'not supported')
             _abort()
 
 def _usage_gitdiff():
-    print 'Usage: doconce gitdiff file1 file2 file3'
+    print('Usage: doconce gitdiff file1 file2 file3')
 
 def gitdiff():
     """Make diff of newest and previous version of files (under Git)."""
@@ -9903,19 +9915,19 @@ def gitdiff():
             shutil.copy(filename, old_filename)
             system('git checkout %s %s' % (commits[0], filename))
             old_files.append(old_filename)
-            print 'doconce diff', old_filename, filename
+            print('doconce diff', old_filename, filename)
             #pydiff(filenames, old_files)
 
 def _usage_extract_exercises():
-    print 'Usage: doconce extract_exercises tmp_mako__mydoc.do.txt "--filter=keyword 1;keyword 2; some key word" --exercise_numbering=chapter --examples_as_exercises'
-    print """
+    print('Usage: doconce extract_exercises tmp_mako__mydoc.do.txt "--filter=keyword 1;keyword 2; some key word" --exercise_numbering=chapter --examples_as_exercises')
+    print("""
 Extract exercises to a separate document. Inherit numbering from parent
 document.
 
 Must use tmp_mako__*.do.txt as file to have includes in place.
 Note: extracting exercises may create a need for
 generalized references to the original document (ref[][][]).
-"""
+""")
 
 def extract_exercises():
     if len(sys.argv) < 2:
@@ -9936,8 +9948,8 @@ def extract_exercises():
     # Load .exerinfo file
     exerinfoname = '.%s.exerinfo' % basename.replace('tmp_mako__', '')
     if not os.path.isfile(exerinfoname):
-        print '*** error: you must compile the document with doconce format'
-        print '    before running doconce extract_exercises (need the %s file)' % exerinfoname
+        print('*** error: you must compile the document with doconce format')
+        print('    before running doconce extract_exercises (need the %s file)' % exerinfoname)
         _abort()
     else:
         with open(exerinfoname, 'r') as f:
@@ -9985,7 +9997,7 @@ def extract_exercises():
         if inside_exer:
             # Filter afterwards
             if not isinstance(exer[-1], list):
-                print 'inside exercise, but exer[-1] is not a list', exer[-1]
+                print('inside exercise, but exer[-1] is not a list', exer[-1])
             exer[-1].append(line)
 
             m = re.search(keywords_pattern, line)
@@ -10031,8 +10043,8 @@ def extract_exercises():
                             label = m.group(1)
                             break
                 if label is None:
-                    print '*** error: doconce extract_exercises requires that every exercise has a label!'
-                    print '    Add missing labels!'
+                    print('*** error: doconce extract_exercises requires that every exercise has a label!')
+                    print('    Add missing labels!')
                     _abort()
                 # Find corresponding number info of this exercise
                 if label is not None:
@@ -10058,8 +10070,8 @@ def extract_exercises():
     refs = re.findall(r'ref\{(.+?)\}', filestr)
     for ref in refs:
         if not ref in labels:
-            print '\n*** warning: reference ref{%s} - no label found in document' % ref
-            print '    need generalized reference ref[][][] in the original document for this label!'
+            print('\n*** warning: reference ref{%s} - no label found in document' % ref)
+            print('    need generalized reference ref[][][] in the original document for this label!')
 
     extra_text = ''
     if not has['DATE']:
@@ -10078,4 +10090,4 @@ def extract_exercises():
     f = open(filename, 'w')
     f.write(filestr)
     f.close()
-    print 'exercises extracted to', filename
+    print('exercises extracted to', filename)

--- a/lib/doconce/misc.py
+++ b/lib/doconce/misc.py
@@ -1,17 +1,18 @@
-from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import division
 from past.builtins import execfile
 from future import standard_library
-from functools import reduce
 standard_library.install_aliases()
 from builtins import zip
 from builtins import str
 from builtins import range
 from past.builtins import basestring
 from past.utils import old_div
+from past.utils import old_div
 import os, sys, shutil, re, glob, time, subprocess, codecs
 from .doconce import errwarn
+from functools import reduce
 
 _part_filename = '._%s%03d'
 _part_filename_wildcard = '._*[0-9][0-9][0-9]'
@@ -619,7 +620,7 @@ def get_legal_command_line_options():
     return _legal_command_line_options
 
 def help_format():
-    print("""
+    print(r"""
 doconce format X doconcefile
 
 where X can be any of the formats
@@ -1155,7 +1156,7 @@ def replace():
             f.close()
 
 def _usage_replace_from_file():
-    print("""Usage: doconce replace_from_file file-with-from-to file1 file2 ...
+    print(r"""Usage: doconce replace_from_file file-with-from-to file1 file2 ...
 
 The file must contain two columns with the from and to parts
 for each substitution. Comment lines starting with # are allowed.
@@ -1215,7 +1216,7 @@ def replace_from_file():
             f.close()
 
 def _usage_find():
-    print("""Usage: doconce find expression
+    print(r"""Usage: doconce find expression
 
 Searches for all .do.txt files in subdirectories and
 writes out filename, line number and line containing expression
@@ -1440,7 +1441,7 @@ def _dofix_localURLs(filename, exclude_adr):
 
 
 def _usage_sphinxfix_localURLs():
-    print("""
+    print(r"""
 Usage: doconce sphinxfix_localURLs file1.rst file2.rst ... -not adr1 adr2 ...
 
 Each link to a local file, e.g., "link": "src/dir1/myfile.txt",
@@ -1492,7 +1493,7 @@ def sphinxfix_localURLs():
 
 def _usage_latex_exercise_toc():
     print('Usage: doconce latex_exercise_toc myfile.do.txt ["List of exercises"]')
-    print("""
+    print(r"""
 Can insert
 # Short: My own short title
 in the text of an exercise and this defines a short version of the
@@ -1609,7 +1610,7 @@ def latex_exercise_toc():
 
 
 def _usage_combine_images():
-    print("""\
+    print(r"""\
 Usage: doconce combine_images [pdf|png] [-4] image1 image2 ... output_file
 Applies montage if not PDF or EPS images, else
 pdftk, pdfnup and pdfcrop.
@@ -1691,7 +1692,7 @@ def combine_images():
 
 def _usage_expand_commands():
     print('Usage: doconce expand_commands file1 file2 ...')
-    print("""
+    print(r"""
 A file .expand_commands may define _replace and _regex_subst lists
 for str.replace and re.sub substitutions (respectively) to be applied
 to file1 file2 ...
@@ -2146,7 +2147,7 @@ download preprocess from http://code.google.com/p/preprocess""")
             output = subprocess.check_output(cmd, shell=True,
                                              stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:
-            print("""You have requested the minted latex style, but this
+            print(r"""You have requested the minted latex style, but this
 requires the pygments package to be installed. On Debian/Ubuntu: run
 Terminal> sudo apt-get install python-pygments
 Or
@@ -2185,7 +2186,7 @@ def replace_code_command(filestr):
                     break
             if alt_verb_delimiter is None:
                 alt_verb_delimiter = alt_verb_delimiters[0]
-                print("""
+                print(r"""
 *** warning: inline verbatim "%s"
     contains all delimiters %s that the LaTeX
     command \\Verb can make use of - be prepared for strange output that
@@ -2657,7 +2658,7 @@ def html_colorbullets():
         f.close()
 
 def _usage_split_html():
-    print("""
+    print(r"""
 Usage: doconce split_html mydoc.html --method=... --nav_button=name --pagination --reference="acknowledgment/author" --font_size=slides --copyright=everypage|titlepage
 
 --method=split|space8|hrule|colorline specifies pagebreak
@@ -2779,7 +2780,7 @@ h2 {font-size: 180%;}
 
 
 def _usage_slides_html():
-    print("""
+    print(r"""
 Usage: doconce slides_html mydoc.html slide_type --html_slide_theme=themename --html_footer_logo=name --nav_button=name --font_size=slides --copyright=everypage|titlepage
 
 slide_type: reveal deck csss dzslides
@@ -3171,13 +3172,13 @@ def doconce_split_html(header, parts, footer, basename, filename, slides=False):
                 # Bootstrap style
                 text += '\n<ul class="pager">\n'
                 if pn > 0:
-                    text += """\
+                    text += r"""\
   <li class="previous">
     <a href="%s">&larr; Prev</a>
   </li>
 """ % prev_part_filename
                 if pn < len(parts)-1:
-                    text += """\
+                    text += r"""\
   <li class="next">
     <a href="%s">Next &rarr;</a>
   </li>
@@ -3429,7 +3430,7 @@ def doconce_split_html(header, parts, footer, basename, filename, slides=False):
                 header_part_line_filename = html_imagefile(header_part_line)
             else:
                 header_part_line_filename = 'http://hplgit.github.io/doconce/bundled/html_images/%s.png' % header_part_line
-            lines.append("""
+            lines.append(r"""
 <p><br><img src="%s"><p><br><p>
 """ % header_part_line_filename)
 
@@ -3463,21 +3464,21 @@ def doconce_split_html(header, parts, footer, basename, filename, slides=False):
                 lines.append('<table style="width: 100%"><tr><td>\n')
                 if pn > 0:
                     if nav_button == 'text':
-                        lines.append("""\
+                        lines.append(r"""\
 <div style="text-align: left;"><a href="%s">&laquo; Previous</a></div>
 """ % (prev_part_filename))
                     else:
-                        lines.append("""\
+                        lines.append(r"""\
 <div style="text-align: left;"><a href="%s"><img src="%s" border=0 alt="&laquo; Previous"></a></div>
 """ % (prev_part_filename, prev_button_filename))
                 lines.append('</td><td>\n')
                 if pn < len(parts)-1:
                     if nav_button == 'text':
-                        lines.append("""\
+                        lines.append(r"""\
 <div style="text-align: right;"><a href="%s">Next &raquo;</a></div>
 """ % (next_part_filename))
                     else:
-                        lines.append("""\
+                        lines.append(r"""\
 <div style="text-align: right;"><a href="%s"><img src="%s" border=0 alt="Next &raquo;"></a></div>
 """ % (next_part_filename, next_button_filename))
                 lines.append('</td></tr></table>\n')
@@ -3505,21 +3506,21 @@ def doconce_split_html(header, parts, footer, basename, filename, slides=False):
             lines.append('<table style="width: 100%"><tr><td>\n')
             if pn > 0:
                 if nav_button == 'text':
-                    lines.append("""\
+                    lines.append(r"""\
 <div style="text-align: left;"><a href="%s">&laquo; Previous</a></div>
 """ % (prev_part_filename))
                 else:
-                    lines.append("""\
+                    lines.append(r"""\
 <div style="text-align: left;"><a href="%s"><img src="%s" border=0 alt="&laquo; Previous"></a></div>
 """ % (prev_part_filename, prev_button_filename))
             lines.append('</td><td>\n')
             if pn < len(parts)-1:
                 if nav_button == 'text':
-                    lines.append("""\
+                    lines.append(r"""\
 <div style="text-align: right;"><a href="%s">Next &raquo;</a></div>
 """ % (next_part_filename))
                 else:
-                    lines.append("""\
+                    lines.append(r"""\
 <div style="text-align: right;"><a href="%s"><img src="%s" border=0 alt="Next &raquo;"></a></div>
 """ % (next_part_filename, next_button_filename))
             lines.append('</td></tr></table>\n')
@@ -4847,7 +4848,7 @@ hr.figure { border: 0; width: 80%%; border-bottom: 1px solid #aaa}
         footer_logo = 'uio_footer'
 
     # Default footer logo command
-    repl = """
+    repl = r"""
 <div style="position: absolute; bottom: 0px; left: 0; margin-left: 0px;">
 <img src="%s/cbc_footer.png" width=110%%;></div>
 """ % footer_logo
@@ -4861,37 +4862,37 @@ hr.figure { border: 0; width: 80%%; border-bottom: 1px solid #aaa}
     if footer_logo == 'cbc_footer':
         if slide_tp not in ('reveal', 'deck'):
             raise ValueError('slide type "%s" cannot have --html_footer_logo' ^ slide_tp)
-        repl = """
+        repl = r"""
 <div style="position: absolute; bottom: 0px; left: 0; margin-left: 0px;">
 <img src="%s/cbc_footer.png" width=110%%;></div>
 """ % footer_logo_path[slide_tp]
     elif footer_logo == 'cbc_symbol':
-        repl = """
+        repl = r"""
 <div style="position: absolute; bottom: 0px; left: 0; margin-left: 20px; margin-bottom: 20px;">
 <img src="%s/cbc_symbol.png" width="50"></div>
 """ % footer_logo_path[slide_tp]
     elif footer_logo == 'simula_footer':
-        repl = """
+        repl = r"""
 <div style="position: absolute; bottom: 0px; left: 0; margin-left: 0px;">
 <img src="%s/simula_footer.png" width=700></div>
 """ % footer_logo_path[slide_tp]
     elif footer_logo == 'simula_symbol':
-        repl = """
+        repl = r"""
 <div style="position: absolute; bottom: 0px; left: 0; margin-left: 20px; margin-bottom: 10px;">
 <img src="%s/simula_symbol.png" width=200></div>
 """ % footer_logo_path[slide_tp]
     elif footer_logo == 'uio_footer':
-        repl = """
+        repl = r"""
 <div style="position: absolute; bottom: 0px; left: 0; margin-left: 20px; margin-bottom: 0px;">
 <img src="%s/uio_footer.png" width=450></div>
 """ % footer_logo_path[slide_tp]
     elif footer_logo == 'uio_symbol':
-        repl = """
+        repl = r"""
 <div style="position: absolute; bottom: 0px; left: 0; margin-left: 20px; margin-bottom: 20px;">
 <img src="%s/uio_symbol.png" width=100></div>
 """ % footer_logo_path[slide_tp]
     elif footer_logo == 'uio_simula_symbol':
-        repl = """
+        repl = r"""
 <div style="position: absolute; bottom: 0px; left: 0; margin-left: 20px; margin-bottom: 0px;">
 <img src="%s/uio_footer.png" width="180"></div>
 <div style="position: absolute; bottom: 0px; left: 0; margin-left: 250px; margin-bottom: 0px;">
@@ -4943,7 +4944,7 @@ hr.figure { border: 0; width: 80%%; border-bottom: 1px solid #aaa}
     slide_syntax[slide_tp]['body_lines'] = ''.join(body_lines)
 
     #<title>%(title)s</title>
-    slides = """\
+    slides = r"""\
 <!DOCTYPE html>
 
 %(head_lines)s
@@ -5133,7 +5134,7 @@ td.padding {
         if html_copyright_placement == 'titlepage' and part_no > 0:
             copyright_ = ''
 
-        slides += """
+        slides += r"""
 %s
 %s
 %s
@@ -5143,7 +5144,7 @@ td.padding {
        part,
        copyright_,
        slide_syntax[slide_tp]['slide_envir_end'])
-    slides += """
+    slides += r"""
 %s
 
 </body>
@@ -5170,7 +5171,7 @@ td.padding {
 
 
 def _usage_slides_beamer():
-    print("""Usage: doconce slides_beamer mydoc --beamer_slide_theme=themename --beamer_slide_navigation=off --beamer_block_style=mdbox [--handout])
+    print(r"""Usage: doconce slides_beamer mydoc --beamer_slide_theme=themename --beamer_slide_navigation=off --beamer_block_style=mdbox [--handout])
 
 themename can be
 red_plain, blue_plain, red_shadow, blue_shadow, dark, dark_gradient, vintage
@@ -5224,7 +5225,7 @@ def slides_beamer():
 
 
 def _usage_slides_markdown():
-    print("""
+    print(r"""
 Usage: doconce slides_markdown mydoc slide_type --slide_theme=dark
 
 slide_type: remark (the only implemented so far)
@@ -5258,7 +5259,7 @@ def slides_markdown():
     if slide_type != 'remark':
         print('*** error: only remark slides are allowed, not %s' % slide_type)
 
-    template = """
+    template = r"""
 <!DOCTYPE html>
 <html>
 <head>
@@ -5302,7 +5303,7 @@ h1, h2, h3 {
     additional_styling = ''
     if theme == 'dark':
         class_ = 'class: center, middle, inverse'
-        additional_styling = """
+        additional_styling = r"""
 
 /* Style taken from the official remark demo */
 body { font-family: 'Droid Serif'; }
@@ -5540,7 +5541,7 @@ def generate_beamer_slides(header, parts, footer, basename, filename):
 """ % vars()
 
     if handout:
-        slides += """
+        slides += r"""
 \usepackage{pgfpages} % for handouts
 """
 
@@ -5828,7 +5829,7 @@ def generate_beamer_slides(header, parts, footer, basename, filename):
 %(part)s
 \end{frame}
 """ % vars()
-    slides += """
+    slides += r"""
 \end{document}
 """
     slides = re.sub(r'% !split\s+', '', slides)
@@ -5912,7 +5913,7 @@ def split_rst0():
 
 def _usage_split_rst():
     print('Usage: doconce split_rst mydoc')
-    print("""Example:
+    print(r"""Example:
 doconce sphinx_dir author="Kaare Dump" title="Short title" dirname=mydir mydoc
 doconce format sphinx mydoc
 doconce split_rst mydoc
@@ -5977,21 +5978,21 @@ def doconce_rst_split(parts, basename, filename):
             first_heading = m.group(1)
             if first_heading.startswith('='):
                 if re.search(r'^(%%+)$', text, flags=re.MULTILINE):
-                    print("""
+                    print(r"""
 *** error: first heading in part %d is a section, but the part
     also contains a chapter.
     !split must be moved to avoid such inconsistent reST headings""" % pn)
                     _abort()
             elif first_heading.startswith('-'):
                 if re.search(r'^(%%+|==+)$', text, flags=re.MULTILINE):
-                    print("""
+                    print(r"""
 *** error: first heading in part %d is a subsection, but the part
     also contains a chapter or section.
     !split must be moved to avoid such inconsistent reST headings""" % pn)
                     _abort()
             elif first_heading.startswith('~'):
                 if re.search(r'^(%%+|==+|--+)$', text, flags=re.MULTILINE):
-                    print("""
+                    print(r"""
 *** error: first heading in part %d is a subsubsection, but the part
     also contains a chapter, section, or subsection.
     !split must be moved to avoid such inconsistent reST headings""" % pn)
@@ -6001,7 +6002,7 @@ def doconce_rst_split(parts, basename, filename):
         generated_files.append(part_filename)
 
         if nbsp and pn > 0 and '|nbsp|' in text:
-            text = """
+            text = r"""
 
 .. |nbsp| unicode:: 0xA0
    :trim:
@@ -6105,7 +6106,7 @@ def teamod():
     os.mkdir('src-%s' % name)
     os.mkdir('slides-%s' % name)
     f = open('main_%s.do.txt' % name, 'w')
-    f.write("""# Main file for teaching module "%s"
+    f.write(r"""# Main file for teaching module "%s"
 
 TITLE: Here Goes The Title ...
 AUTHOR: name1 email:..@.. at institution1, institution2, ...
@@ -6116,7 +6117,7 @@ DATE: today
 """ % name)
     f.close()
     f = open('%s.do.txt' % name, 'w')
-    f.write("""# Teaching module: %s
+    f.write(r"""# Teaching module: %s
 ======= Section =======
 
 ===== Subsection =====
@@ -6829,7 +6830,7 @@ def _spellcheck_all(**kwargs):
         sys.exit(0)
 
 def _usage_spellcheck():
-    print("""
+    print(r"""
 doconce spellcheck file1.do.txt file2.do.txt ...  # use .dict4spell.txt
 doconce spellcheck -d .mydict.txt file1.do.txt file2.do.txt ...
 
@@ -7222,7 +7223,7 @@ def ref_external():
 
 def _usage_latex_problems():
     print('doconce latex_problems mydoc.log [overfull-hbox-limit --texcode]')
-    print("""
+    print(r"""
 Interpret the .log file and write out latex problems related to
 undefined references, multiply defined labels, and overfull hboxes.
 The lower limit for overfull hboxes can be specified as an integer.
@@ -8454,7 +8455,7 @@ def latex2doconce():
     by files combined to a single file, avoid footnotes, index inside
     paragraphs, do not start code blocks with indentation, ...
     """
-    print("""# #ifdef LATEX2DOCONCE
+    print(r"""# #ifdef LATEX2DOCONCE
 This is the result of the doconce latex2doconce program.
 The translation from LaTeX is just a helper. The text must
 be carefully examined! (Be prepared that some text might also
@@ -8476,7 +8477,7 @@ def html2doconce():
     Apply transformations to an html file to help translate the
     document into DocOnce format.
     """
-    print("""# #ifdef HTML2DOCONCE
+    print(r"""# #ifdef HTML2DOCONCE
 This is the result of the doconce htmldoconce program.
 The translation from HTML is just a helper. The text must
 be carefully examined! (Be prepared that some text might also
@@ -8609,11 +8610,11 @@ def latex_dislikes():
                 if envir in begin_likes:
                     pass # fine!
                 elif envir in begin_ok:
-                    print("""
+                    print(r"""
 Found \\begin{%s}, which can be handled, but it is
 recommended to avoid this construction.""" % envir)
                 else:
-                    print("""
+                    print(r"""
 Found \\begin{%s}, which will not carry over to DocOnce
 and other formats.""" % envir)
                     # Could have message here (begin_messages) that
@@ -8659,7 +8660,7 @@ def ipynb2doconce():
 
     # checking if we have modern enough ipynb format
     if nb['nbformat'] < 4:
-        print("""*** error: ipynb file format is too old (at least v4 needed).
+        print(r"""*** error: ipynb file format is too old (at least v4 needed).
 Please, upgrade format of your ipynb-file using Jupyter (just open and save
 the file) and then try again.
 """)
@@ -8992,7 +8993,7 @@ def pygmentize():
 
 def _usage_makefile():
     print('Usage:   doconce makefile doconce-file [html pdflatex latex sphinx gwiki pandoc ipynb deck reveal beamer ...]')
-    print("""Example: doconce makefile mydoc.do.txt html sphinx'
+    print(r"""Example: doconce makefile mydoc.do.txt html sphinx'
 
 A script make.py is generated with the basic steps for running a
 spellcheck on .do.txt files followed by commands for producing
@@ -9308,7 +9309,7 @@ def main():
 
     for format in formats:
         if format.endswith('latex'):
-            make.write("""
+            make.write(r"""
     # --- latex ---
 
     common_latex_options = ' --latex_code_style=vrb'
@@ -9322,7 +9323,7 @@ def main():
           postfix='auto')
 """)
         elif format == 'html':
-            make.write("""
+            make.write(r"""
     # --- HTML ---
 
     common_html_options = ''
@@ -9342,7 +9343,7 @@ def main():
     #html(dofile, options=common_options + common_html_options + ' --html_style=solarized3 --html_output=%s-solarized' % dofile, split=True)
 """)
         elif format == 'sphinx':
-            make.write("""
+            make.write(r"""
     # --- Sphinx ---
 
     sphinx_themes = ['pyramid',]
@@ -9357,7 +9358,7 @@ def main():
           split=False)
 """)
         elif format == 'reveal':
-            make.write("""
+            make.write(r"""
 
     # --- reveal.js slides ---
 
@@ -9368,7 +9369,7 @@ def main():
       theme='darkgray')
 """)
         elif format == 'deck':
-            make.write("""
+            make.write(r"""
     # --- deck.js slides ---
 
     deck_slides(
@@ -9378,7 +9379,7 @@ def main():
       theme='sandstone.default')
 """)
         elif format == 'beamer':
-            make.write("""
+            make.write(r"""
     # --- latex beamer slides ---
 
     beamer_slides(
@@ -9389,7 +9390,7 @@ def main():
       ptex2tex_envir='minted')  # 'ans:nt'
 """)
         elif format.endswith('wiki') or format in ('pandoc', 'plain', 'ipynb'):
-            make.write("""
+            make.write(r"""
     doconce2format(dofile, format, options=common_options + '')
 
 """)
@@ -9401,13 +9402,13 @@ def main():
         with_toc = ' -DWITH_TOC' if 'WITH_TOC' in text else ''
 
         dofile = dofile[:-7]
-        make.write("""
+        make.write(r"""
     # Slides file %(dofile)s
     dofile = "%(dofile)s"
 """ % vars())
         for format in formats:
             if format == 'html':
-                make.write("""
+                make.write(r"""
     html_style = 'bloodish'
     # One long HTML file
     html(
@@ -9442,7 +9443,7 @@ def main():
       theme='sandstone.default')
 """)
             elif format.endswith('latex'):
-                make.write("""
+                make.write(r"""
     beamer_slides(
       dofile,
       options=common_options + ' --latex_code_style=pyg',
@@ -9456,7 +9457,7 @@ def main():
       options=common_options + ' --device=paper' + with_toc,
       )
 """)
-    make.write("""
+    make.write(r"""
     # Dump all Unix commands run above as a Bash script
     bash = open('tmp_make.sh', 'w')
     print 'see tmp_make.sh for an equivalent auto-generated unix script'
@@ -9482,7 +9483,7 @@ function system {
 
     print 'see tmp_output.log for the output of all the commands'
 """)
-    make.write("""
+    make.write(r"""
 
 if __name__ == '__main__':
     main()
@@ -9495,7 +9496,7 @@ if __name__ == '__main__':
 
 def _usage_fix_bibtex4publish():
     print('Usage: doconce fix_bibtex4publish fil1e.bib file2.bib ...')
-    print("""
+    print(r"""
 Fix a bibtex file so that the values are enclosed by braces (only)
 and publish can import the data.
 """)
@@ -9920,7 +9921,7 @@ def gitdiff():
 
 def _usage_extract_exercises():
     print('Usage: doconce extract_exercises tmp_mako__mydoc.do.txt "--filter=keyword 1;keyword 2; some key word" --exercise_numbering=chapter --examples_as_exercises')
-    print("""
+    print(r"""
 Extract exercises to a separate document. Inherit numbering from parent
 document.
 

--- a/lib/doconce/mwiki.py
+++ b/lib/doconce/mwiki.py
@@ -30,13 +30,17 @@ demo and fill out that page with the content of a mydoconcefile.wiki,
 sometimes it is necessary to create a new account, just do that and
 go back.
 """
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import range
 
 
-import re, os, commands, sys, subprocess
-from common import default_movie, plain_exercise, insert_code_and_tex
-from plaintext import plain_quiz
-from misc import _abort
-from doconce import errwarn
+import re, os, subprocess, sys, subprocess
+from .common import default_movie, plain_exercise, insert_code_and_tex
+from .plaintext import plain_quiz
+from .misc import _abort
+from .doconce import errwarn
 
 def align2equations(math_text):
     """
@@ -192,14 +196,14 @@ def mwiki_figure(m):
 
         # Skip directories - get the basename
         filename = os.path.basename(filename)
-        import urllib
-        prms = urllib.urlencode({
+        import urllib.request, urllib.parse, urllib.error
+        prms = urllib.parse.urlencode({
             'action': 'query', 'titles': 'Image:' + filename,
             'prop': 'imageinfo', 'format': 'xml'})
         url = 'http://en.wikipedia.org/w/api.php?' + prms
         try:
             errwarn(' ...checking if %s is stored at en.wikipedia.org/w/api.php...' % filename)
-            f = urllib.urlopen(url)
+            f = urllib.request.urlopen(url)
 
             imageinfo = f.read()
             f.close()
@@ -245,7 +249,7 @@ def mwiki_figure(m):
 
     return result
 
-from common import table_analysis
+from .common import table_analysis
 
 
 def mwiki_author(authors_and_institutions, auth2index,
@@ -274,7 +278,7 @@ def mwiki_author(authors_and_institutions, auth2index,
     # we skip institutions in mwiki
     return text
 
-from gwiki import wiki_ref_and_label_common
+from .gwiki import wiki_ref_and_label_common
 
 def mwiki_ref_and_label(section_label2title, format, filestr):
     return wiki_ref_and_label_common(section_label2title, format, filestr)
@@ -389,7 +393,7 @@ def define(FILENAME_EXTENSION,
         }
 
     CODE['mwiki'] = mwiki_code
-    from html import html_table
+    from .html import html_table
     TABLE['mwiki'] = html_table
     ENVIRS['mwiki'] = {
         'warning':   lambda block, format, title='Warning', text_size='normal':
@@ -435,7 +439,7 @@ def define(FILENAME_EXTENSION,
         'search': ('.png', '.gif', '.jpg', '.jpeg'),
         'convert': ('.png', '.gif', '.jpg')}
     CROSS_REFS['mwiki'] = mwiki_ref_and_label
-    from plaintext import plain_index_bib
+    from .plaintext import plain_index_bib
     EXERCISE['mwiki'] = plain_exercise
     INDEX_BIB['mwiki'] = plain_index_bib
     TOC['mwiki'] = lambda s, f: '<<<TOC>>>'  # __TOC__ will be wrongly translated to paragraph headline and needs a fix

--- a/lib/doconce/pandoc.py
+++ b/lib/doconce/pandoc.py
@@ -2,6 +2,10 @@
 See http://johnmacfarlane.net/pandoc/README.html
 for syntax.
 """
+from __future__ import absolute_import
+from builtins import zip
+from builtins import range
+from past.builtins import basestring
 # Remaining key issue: github_md dialect hardcodes all the newlines so
 # lines in paragraphs should be joined if the resulting Markdown text
 # is published as an issue on github.com. (Difficult to solve. Current
@@ -9,11 +13,11 @@ for syntax.
 # documents and issues.)
 
 import re, sys, functools
-from common import default_movie, plain_exercise, table_analysis, \
+from .common import default_movie, plain_exercise, table_analysis, \
      insert_code_and_tex, bibliography, indent_lines, fix_ref_section_chapter
-from html import html_movie, html_table
-from misc import option
-from doconce import errwarn
+from .html import html_movie, html_table
+from .misc import option
+from .doconce import errwarn
 
 # Mapping of envirs to correct Pandoc verbatim environment
 language2pandoc = dict(
@@ -487,7 +491,7 @@ def define(FILENAME_EXTENSION,
             'box':      slate_success,
             }
 
-    from common import DEFAULT_ARGLIST
+    from .common import DEFAULT_ARGLIST
     ARGLIST['pandoc'] = DEFAULT_ARGLIST
     LIST['pandoc'] = {
         'itemize':

--- a/lib/doconce/pdflatex.py
+++ b/lib/doconce/pdflatex.py
@@ -1,7 +1,7 @@
+# -*- coding: iso-8859-15 -*-
 from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
-# -*- coding: iso-8859-15 -*-
 from .latex import *
 from .doconce import errwarn
 

--- a/lib/doconce/pdflatex.py
+++ b/lib/doconce/pdflatex.py
@@ -1,6 +1,9 @@
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 # -*- coding: iso-8859-15 -*-
-from latex import *
-from doconce import errwarn
+from .latex import *
+from .doconce import errwarn
 
 def pdflatex_emoji(m):
     space1 = m.group(1)
@@ -11,10 +14,10 @@ def pdflatex_emoji(m):
     emojifile = os.path.join(latexfigdir, name + '.png')
     if not os.path.isfile(emojifile):
         # Download emoji image
-        from common import emoji_url
+        from .common import emoji_url
         url = emoji_url + name + '.png'
-        import urllib
-        urllib.urlretrieve(url, filename=emojifile)
+        import urllib.request, urllib.parse, urllib.error
+        urllib.request.urlretrieve(url, filename=emojifile)
         # Check that this was successful
         with open(emojifile, 'r') as f:
             if 'Not Found' in f.read():
@@ -44,7 +47,7 @@ def define(FILENAME_EXTENSION,
 
     if not 'latex' in BLANKLINE:
         # latex.define is not yet ran on these dictionaries, do it:
-        import latex
+        from . import latex
         latex.define(FILENAME_EXTENSION,
                      BLANKLINE,
                      INLINE_TAGS_SUBST,

--- a/lib/doconce/plaintext.py
+++ b/lib/doconce/plaintext.py
@@ -1,7 +1,11 @@
+from __future__ import absolute_import
+from builtins import str
+from builtins import range
+from past.builtins import basestring
 import re, sys
-from common import default_movie, plain_exercise, bibliography, \
+from .common import default_movie, plain_exercise, bibliography, \
      cite_with_multiple_args2multiple_cites, fix_ref_section_chapter
-from misc import option
+from .misc import option
 
 
 def plain_author(authors_and_institutions, auth2index,
@@ -35,7 +39,7 @@ def plain_ref_and_label(section_label2title, format, filestr):
         filestr = filestr.replace('ref{%s}' % label,
                                   '"%s"' % section_label2title[label])
 
-    from common import ref2equations
+    from .common import ref2equations
     filestr = ref2equations(filestr)
 
     return filestr
@@ -215,9 +219,9 @@ def define(FILENAME_EXTENSION,
         'ampersand2':    r' \g<1>&\g<2>',
         }
 
-    from rst import rst_code
+    from .rst import rst_code
     CODE['plain'] = rst_code
-    from common import DEFAULT_ARGLIST
+    from .common import DEFAULT_ARGLIST
     ARGLIST['plain'] = DEFAULT_ARGLIST
     LIST['plain'] = {
         'itemize':
@@ -232,14 +236,14 @@ def define(FILENAME_EXTENSION,
         'separator': '\n',
         }
     CROSS_REFS['plain'] = plain_ref_and_label
-    from rst import rst_table
+    from .rst import rst_table
     TABLE['plain'] = rst_table
     #TABLE['plain'] = plain_table
     EXERCISE['plain'] = plain_exercise
     INDEX_BIB['plain'] = plain_index_bib
     TOC['plain'] = plain_toc
 
-    from common import indent_lines
+    from .common import indent_lines
     ENVIRS['plain'] = {
         'warning':   lambda block, format, title='Warning', text_size='normal':
            plain_box(block, title),

--- a/lib/doconce/publish_doconce.py
+++ b/lib/doconce/publish_doconce.py
@@ -1,3 +1,4 @@
+from builtins import str
 from publish import config
 _format_venue = config.formatting._format_venue
 from publish.common import short_author
@@ -30,7 +31,7 @@ def doconce_format_articles(paper):
     # Volume
     if "volume" in paper:
         vol = paper["volume"]
-        if paper.has_key("number") :
+        if "number" in paper :
             vol += "(%s)" % paper["number"]
         values.append(vol)
 
@@ -293,7 +294,7 @@ def _doconce_get_authors_string(authors):
 
 def _doconce_mark_author(author, text) :
   "Mark the text with bold face if author is in the list of marked authors"
-  if config.has_key("mark_author") and author.strip() in config.get("mark_author") :
+  if "mark_author" in config and author.strip() in config.get("mark_author") :
     return "_%s_" % text
   else:
     return text
@@ -378,7 +379,7 @@ def rst_format_articles(paper):
     # Volume
     if "volume" in paper:
         vol = paper["volume"]
-        if paper.has_key("number") :
+        if "number" in paper :
             vol += "(%s)" % paper["number"]
         values.append(vol)
 
@@ -627,7 +628,7 @@ def _rst_get_authors_string(authors):
 
 def _rst_mark_author(author, text) :
   "Mark the text with bold face if author is in the list of marked authors"
-  if config.has_key("mark_author") and author.strip() in config.get("mark_author") :
+  if "mark_author" in config and author.strip() in config.get("mark_author") :
     return "_%s_" % text
   else:
     return text
@@ -887,7 +888,7 @@ def _xml_get_authors_string(authors):
 
 def _xml_mark_author(author, text):
   "Mark the text with bold face if author is in the list of marked authors"
-  if config.has_key("mark_author") and author.strip() in config.get("mark_author") :
+  if "mark_author" in config and author.strip() in config.get("mark_author") :
     return '<author marked="True">%s</author>' % text
   else:
     return '<author marked="False">%s</author>' % text

--- a/lib/doconce/publish_doconce.py
+++ b/lib/doconce/publish_doconce.py
@@ -294,7 +294,7 @@ def _doconce_get_authors_string(authors):
 
 def _doconce_mark_author(author, text) :
   "Mark the text with bold face if author is in the list of marked authors"
-  if "mark_author" in config and author.strip() in config.get("mark_author") :
+  if config.has_key("mark_author") and author.strip() in config.get("mark_author") :
     return "_%s_" % text
   else:
     return text
@@ -628,7 +628,7 @@ def _rst_get_authors_string(authors):
 
 def _rst_mark_author(author, text) :
   "Mark the text with bold face if author is in the list of marked authors"
-  if "mark_author" in config and author.strip() in config.get("mark_author") :
+  if config.has_key("mark_author") and author.strip() in config.get("mark_author") :
     return "_%s_" % text
   else:
     return text
@@ -888,7 +888,7 @@ def _xml_get_authors_string(authors):
 
 def _xml_mark_author(author, text):
   "Mark the text with bold face if author is in the list of marked authors"
-  if "mark_author" in config and author.strip() in config.get("mark_author") :
+  if config.has_key("mark_author") and author.strip() in config.get("mark_author") :
     return '<author marked="True">%s</author>' % text
   else:
     return '<author marked="False">%s</author>' % text

--- a/lib/doconce/rst.py
+++ b/lib/doconce/rst.py
@@ -443,8 +443,8 @@ def rst_bib(filestr, citations, pubfile, pubdata, numbering=True):
                 except UnicodeDecodeError as e:
                     if "can't decode byte" in str(e):
                         try:
-                            bibtext = bibtext.decode('utf-8').replace(
-                                '[%s]' % label, cite % citations[label])
+                            bibtext = bibtext.replace('[%s]' % label, 
+                                                      cite % citations[label])
                         except UnicodeDecodeError as e:
                             errwarn('UnicodeDecodeError: ' + e)
                             errwarn('*** error: problems in %s' % pubfile)

--- a/lib/doconce/rst.py
+++ b/lib/doconce/rst.py
@@ -1,10 +1,15 @@
+from __future__ import absolute_import
+from builtins import zip
+from builtins import str
+from builtins import range
+from past.builtins import basestring
 import re, os, sys
-from common import insert_code_and_tex, indent_lines, \
+from .common import insert_code_and_tex, indent_lines, \
     table_analysis, plain_exercise, bibliography, \
     cite_with_multiple_args2multiple_cites, fix_ref_section_chapter
-from html import html_movie, html_quiz
-from doconce import _abort, errwarn, locale_dict
-from misc import option, _abort
+from .html import html_movie, html_quiz
+from .doconce import _abort, errwarn, locale_dict
+from .misc import option, _abort
 
 def rst_abstract(m):
     # r'\n*\g<type>.* \g<text>\n\g<rest>'
@@ -138,7 +143,7 @@ def rst_code(filestr, code_blocks, code_block_types,
 
     if option('rst_mathjax') and (re.search(r'^!bt', filestr, flags=re.MULTILINE) or re.search(r'\\\( .+ \\\)', filestr)):
         # First add MathJax script in the very beginning of the file
-        from html import mathjax_header
+        from .html import mathjax_header
         latex = indent_lines(mathjax_header(filestr).lstrip(), 'rst')
         filestr = '\n.. raw:: html\n\n' + latex + '\n\n' + filestr
         # Replace all the !bt parts by raw html directive (make sure
@@ -385,7 +390,7 @@ def ref_and_label_commoncode(section_label2title, format, filestr):
     filestr = cpattern.sub('', filestr)
     filestr = re.sub(r'label\{[^}]+?\}', '', filestr)  # all the remaining
 
-    import doconce
+    from . import doconce
     doconce.debugpr(debugtext)
 
     return filestr
@@ -399,7 +404,7 @@ def rst_ref_and_label(section_label2title, format, filestr):
         filestr = filestr.replace('ref{%s}' % label,
                                   '`%s`_' % section_label2title[label])
 
-    from common import ref2equations
+    from .common import ref2equations
     filestr = ref2equations(filestr)
     # replace remaining ref{x} as x_
     filestr = re.sub(r'ref\{(.+?)\}', '`\g<1>`_', filestr)
@@ -708,7 +713,7 @@ def define(FILENAME_EXTENSION,
 
         'separator': '\n',
         }
-    from common import DEFAULT_ARGLIST
+    from .common import DEFAULT_ARGLIST
     ARGLIST['rst'] = DEFAULT_ARGLIST
     FIGURE_EXT['rst'] = {
         'search': ('.png', '.gif', '.jpg', '.jpeg', '.pdf', '.eps', '.ps'),
@@ -726,7 +731,7 @@ def define(FILENAME_EXTENSION,
 
 """
     # http://stackoverflow.com/questions/11830242/non-breaking-space
-    from common import INLINE_TAGS
+    from .common import INLINE_TAGS
     if re.search(INLINE_TAGS['non-breaking-space'], filestr):
         nbsp = """
 .. |nbsp| unicode:: 0xA0
@@ -734,7 +739,7 @@ def define(FILENAME_EXTENSION,
 
 """
         if 'TITLE:' not in filestr:
-            import common
+            from . import common
             if common.format in ('rst', 'sphinx'):
                 errwarn('*** error: non-breaking space character ~ is used,')
                 errwarn('    but this will give an error when the document does')

--- a/lib/doconce/rst.py
+++ b/lib/doconce/rst.py
@@ -658,7 +658,7 @@ def define(FILENAME_EXTENSION,
         # (note len(m.group('subst')) gives wrong length for latin-1 strings,
         # seems to work for utf-8, if problems: replace lambda function
         # with an ordinary function where you can debug and test!
-        #'chapter':       lambda m: '%s\n%s' % (m.group('subst'), '%'*len(m.group('subst').decode(encoding))),
+        #'chapter':       lambda m: '%s\n%s' % (m.group('subst'), '%'*len(m.group('subst'))),
         'chapter':       lambda m: '%s\n%s' % (m.group('subst'), '%'*len(m.group('subst'))),
         'section':       lambda m: '%s\n%s' % (m.group('subst'), '='*len(m.group('subst'))),
         'subsection':    lambda m: '%s\n%s' % (m.group('subst'), '-'*len(m.group('subst'))),

--- a/lib/doconce/sphinx.py
+++ b/lib/doconce/sphinx.py
@@ -1,11 +1,14 @@
+from __future__ import print_function
+from __future__ import absolute_import
+from builtins import range
 # http://sphinx.pocoo.org/ext/math.html#
 
 # can reuse most of rst module:
-from rst import *
-from common import align2equations, online_python_tutor, \
+from .rst import *
+from .common import align2equations, online_python_tutor, \
      get_legal_pygments_lexers, has_custom_pygments_lexer
-from misc import option, _abort
-from doconce import errwarn
+from .misc import option, _abort
+from .doconce import errwarn
 
 # RunestoneInteractive book counters
 question_counter = 0
@@ -188,7 +191,7 @@ def sphinx_quiz(quiz):
         return rst_quiz(quiz)
 
 
-from latex import fix_latex_command_regex as fix_latex
+from .latex import fix_latex_command_regex as fix_latex
 
 def sphinx_code(filestr, code_blocks, code_block_types,
                 tex_blocks, format):
@@ -333,7 +336,7 @@ def sphinx_code(filestr, code_blocks, code_block_types,
     and references to them will be empty):""")
         for label in multiple_math_labels_with_refs:
             errwarn('    label{%s}' % label)
-        print
+        print()
 
     filestr = insert_code_and_tex(filestr, code_blocks, tex_blocks, 'sphinx')
 
@@ -612,7 +615,7 @@ def sphinx_ref_and_label(section_label2title, format, filestr):
 
 def sphinx_index_bib(filestr, index, citations, pubfile, pubdata):
     filestr = rst_bib(filestr, citations, pubfile, pubdata)
-    from common import INLINE_TAGS
+    from .common import INLINE_TAGS
 
     for word in index:
         # Drop verbatim, emphasize, bold, and math in index
@@ -712,7 +715,7 @@ def define(FILENAME_EXTENSION,
            filestr):
     if not 'rst' in BLANKLINE:
         # rst.define is not yet ran on these dictionaries, do it:
-        import rst
+        from . import rst
         rst.define(FILENAME_EXTENSION,
                    BLANKLINE,
                    INLINE_TAGS_SUBST,

--- a/lib/doconce/st.py
+++ b/lib/doconce/st.py
@@ -1,6 +1,7 @@
+from __future__ import absolute_import
 
-from epytext import epytext_author
-from common import default_movie, plain_exercise, DEFAULT_ARGLIST
+from .epytext import epytext_author
+from .common import default_movie, plain_exercise, DEFAULT_ARGLIST
 
 def define(FILENAME_EXTENSION,
            BLANKLINE,
@@ -53,7 +54,7 @@ def define(FILENAME_EXTENSION,
         'ampersand2':    r' \g<1>&\g<2>',
         }
 
-    from rst import rst_code, rst_table
+    from .rst import rst_code, rst_table
     CODE['st'] = rst_code
     TABLE['st'] = rst_table
 
@@ -70,10 +71,10 @@ def define(FILENAME_EXTENSION,
         'separator': '',
         }
     ARGLIST['st'] = DEFAULT_ARGLIST
-    from plaintext import plain_ref_and_label, plain_index_bib
+    from .plaintext import plain_ref_and_label, plain_index_bib
     CROSS_REFS['st'] = plain_ref_and_label
     INDEX_BIB['st'] = plain_index_bib
     EXERCISE['st'] = plain_exercise
     TOC['st'] = lambda s, f: ''  # drop
-    from plaintext import plain_quiz
+    from .plaintext import plain_quiz
     QUIZ['st'] = plain_quiz

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ man_filename = os.path.join("doc", "man", "man1", "doconce.1")
 if "install" in sys.argv:
     # Compresses the man page
     try:
-        man_inputfile = open(man_filename, 'r')
+        man_inputfile = open(man_filename, 'rb')
         man_contents = man_inputfile.read()
         man_inputfile.close()
 

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,8 @@ Usage of this setup.py script:
 python setup.py install [, --prefix=$PREFIX]
 
 """
+from __future__ import print_function
+from builtins import str
 __author__ = 'Hans Petter Langtangen <hpl@simula.no>'
 __acknowledgemets__ = 'Johannes H. Ring',
 
@@ -37,8 +39,8 @@ if "install" in sys.argv:
         man_outputfile.close()
 
         man_filename = tmp_filename
-    except IOError, msg:
-        print "Unable to compress man page: %s" % msg
+    except IOError as msg:
+        print("Unable to compress man page: %s" % msg)
 
 # Make doconce_config_default.py file (based on newest set of options)
 import doconce.misc
@@ -93,5 +95,5 @@ setup(
 # Clean up the temporary compressed man page
 if man_filename.endswith(".gz") and os.path.isfile(man_filename):
     if "-q" not in sys.argv or "--quiet" not in sys.argv:
-        print "Removing %s" % man_filename
+        print("Removing %s" % man_filename)
     os.remove(man_filename)

--- a/test/test_copyright.py
+++ b/test/test_copyright.py
@@ -1,9 +1,10 @@
+from __future__ import print_function
 import os, shutil, sys, re, glob
 shutil.copy('copyright.do.txt', 'tmp_copyright.do.txt')
 name = 'tmp_copyright'  # DocOnce file
 
 def system(cmd):
-    print cmd
+    print(cmd)
     failure = os.system(cmd)
     if failure:
         sys.exit(1)
@@ -40,7 +41,7 @@ for format in 'pdflatex', 'sphinx', 'html':
                 cmd += ' --latex_code_style=vrb'
             elif format == 'html':
                 cmd += ' --html_output=%s%d' % (name, counter)
-            print cmd
+            print(cmd)
             system(cmd)
             if format == 'html':
                 cmd = 'doconce split_html %s%d.html' % (name, counter)

--- a/test/test_mintest.py
+++ b/test/test_mintest.py
@@ -1,4 +1,6 @@
 """Minimalistic set of unit tests for DocOnce."""
+from __future__ import print_function
+from builtins import range
 # Note: test.verify is a full test, but requires *a lot* of dependencies.
 # This test can be run with an install of plain DocOnce code (even not
 # preprocess and mako are used).
@@ -87,7 +89,7 @@ def test_mintest_html():
     for filename in filenames:
         assert_equal_files(filename,
                            os.path.join('mintest', filename))
-    print '------- end of html test ------------'
+    print('------- end of html test ------------')
 
 def test_mintest_latex():
     filename = '_ref_mintest'
@@ -99,7 +101,7 @@ def test_mintest_latex():
     filenames = [filename+'.tex']
     for filename in filenames:
         assert_equal_files(filename, os.path.join('mintest', filename))
-    print '------- end of latex test ------------'
+    print('------- end of latex test ------------')
 
 def test_mintest_plain():
     filename = '_ref_mintest'
@@ -111,7 +113,7 @@ def test_mintest_plain():
     filenames = [filename+'.txt']
     for filename in filenames:
         assert_equal_files(filename, os.path.join('mintest', filename))
-    print '------- end of plain text test ------------'
+    print('------- end of plain text test ------------')
 
 def test_mintest_ipynb():
     filename = '_ref_mintest'
@@ -123,7 +125,7 @@ def test_mintest_ipynb():
     filenames = [filename+'.ipynb']
     for filename in filenames:
         assert_equal_files(filename, os.path.join('mintest', filename))
-    print '------- end of plain text test ------------'
+    print('------- end of plain text test ------------')
 
 if __name__ == '__main__':
     test_mintest_html()


### PR DESCRIPTION
This pull request includes changes that should make DocOnce compatible with both Python 2.7 and Python 3.6.

Other versions may also be compatible, but this has not been tested.

This change has been tested on a fairly large book project targeting both Jupyter Notebooks and PDF (LaTeX). There might still be some issues left, so please let me know if you find any use cases where this change breaks anything.

As can be seen from the commit history, most of the conversion is done with futurize. Then a number of manual fixes have been made.