### PR TITLE
Improve ipynb title

### DIFF
--- a/lib/doconce/doconce.py
+++ b/lib/doconce/doconce.py
@@ -3539,7 +3539,7 @@ def typeset_authors(filestr, format):
         index2inst, auth2email, filestr = interpret_authors(filestr, format)
     author_block = INLINE_TAGS_SUBST[format]['author']\
         (authors_and_institutions, auth2index, inst2index,
-         index2inst, auth2email)
+         index2inst, auth2email).rstrip() + '\n'  # ensure one newline
     filestr = filestr.replace('XXXAUTHOR', author_block)
     return filestr
 

--- a/lib/doconce/doconce.py
+++ b/lib/doconce/doconce.py
@@ -18,7 +18,7 @@ except ImportError:
     # use standard arbitrary-ordered dict instead (original order of
     # citations is then lost)
     OrderedDict = dict
-    
+
 # Support for non-English languages (not really implemented yet)
 global locale_dict
 locale_dict = dict(
@@ -2627,7 +2627,7 @@ def typeset_lists(filestr, format, debug_info=[]):
     """
     debugpr('*** List typesetting phase + comments and blank lines ***')
     import string
-    
+
     try:  # Python 2.7 needs the old StringIO
         from StringIO import StringIO
     except ImportError:
@@ -3539,7 +3539,7 @@ def typeset_authors(filestr, format):
         index2inst, auth2email, filestr = interpret_authors(filestr, format)
     author_block = INLINE_TAGS_SUBST[format]['author']\
         (authors_and_institutions, auth2index, inst2index,
-         index2inst, auth2email).rstrip() + '\n'  # ensure one newline
+         index2inst, auth2email)
     filestr = filestr.replace('XXXAUTHOR', author_block)
     return filestr
 

--- a/lib/doconce/ipynb.py
+++ b/lib/doconce/ipynb.py
@@ -34,6 +34,7 @@ def ipynb_author(authors_and_institutions, auth2index,
     # New code: typeset as lines, but insert a comment so we
     # can convert back <!-- dom:AUTHOR: ... ->
     s = '\n'
+    first_pass = True
     for author, i, e in authors_and_institutions:
         s+= '<!-- dom:AUTHOR: ' + author
         if e is not None:
@@ -41,11 +42,16 @@ def ipynb_author(authors_and_institutions, auth2index,
         if i is not None:
             s += ' at ' + ' & '.join(i)
         s += ' -->\n'
-        s+= '<!-- Author: --> _%s_' % (author)
+        # Add extra line between heading and first author
+        if first_pass:
+            s+= '<!-- Author: -->  \n_%s_' % (author)
+        else:
+            s+= '<!-- Author: --> _%s_' % (author)
         if e is not None:
             s += ' (email: `%s`)' % e
         if i is not None:
             s += ', ' + ' and '.join(i)
+        first_pass = False
         s += '  \n'
     return s
 

--- a/lib/doconce/ipynb.py
+++ b/lib/doconce/ipynb.py
@@ -46,7 +46,7 @@ def ipynb_author(authors_and_institutions, auth2index,
             s += ' (email: `%s`)' % e
         if i is not None:
             s += ', ' + ' and '.join(i)
-        s += '\n\n'
+        s += '  \n'
     return s
 
 def ipynb_table(table):


### PR DESCRIPTION
Improves the title in ipython notebooks. Authors are on separate lines, an empty line between heading and authors, and an empty line between authors and date.