### PR TITLE
setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from builtins import str
 __author__ = 'Hans Petter Langtangen <hpl@simula.no>'
 __acknowledgemets__ = 'Johannes H. Ring',
 
-from distutils.core import setup
+from setuptools import setup
 
 import os, sys, glob, gzip, tempfile
 


### PR DESCRIPTION
Changed to using setuptools instead of distutils to have option to `python setup.py develop`.

`develop` links to the code, so when editing the source code the changes are available directly without having to reinstall every time.