### PR TITLE
Add support for automatic execution of code blocks

### DIFF
--- a/lib/doconce/common.py
+++ b/lib/doconce/common.py
@@ -559,7 +559,7 @@ def remove_code_and_tex(filestr, format):
     # ipynb (and future interactive executable documents) needs to
     # see if a code is to be executed or just displayed as text.
     # !bc *cod-t and !bc *pro-t is used to indicate pure text.
-    if format not in ('ipynb', 'matlabnb'):
+    if format not in ('ipynb', 'matlabnb', 'latex', 'pdflatex'):
         filestr = re.sub(r'^!bc +([a-z0-9]+)-t', r'!bc \g<1>',
                          filestr, flags=re.MULTILINE)
     # !bc pypro-h for show/hide button

--- a/lib/doconce/execution.py
+++ b/lib/doconce/execution.py
@@ -1,3 +1,7 @@
+from __future__ import print_function
+from __future__ import division
+from __future__ import unicode_literals
+
 from jupyter_client import KernelManager
 from nbformat.v4 import output_from_msg
 from . import misc

--- a/lib/doconce/execution.py
+++ b/lib/doconce/execution.py
@@ -29,6 +29,7 @@ def run_cell(kernel_client, source, timeout=30, cell_index=0):
             msg = kernel_client.client.shell_channel.get_msg(timeout=timeout)
         except Empty:
             print("Timeout waiting for execute reply", timeout)
+            print("Tried to run the following source:\n{}".format(source))
             try:
                 exception = TimeoutError
             except NameError:

--- a/lib/doconce/execution.py
+++ b/lib/doconce/execution.py
@@ -1,4 +1,4 @@
-from jupyter_client import MultiKernelManager
+from jupyter_client import KernelManager
 from nbformat.v4 import output_from_msg
 from . import misc
 try:
@@ -9,19 +9,18 @@ except ImportError:
 
 class JupyterKernelClient:
     def __init__(self):
-        self.manager = MultiKernelManager()
-        self.kernel_id = self.manager.start_kernel('python3')
-        self.kernel = self.manager.get_kernel(self.kernel_id)
-        self.client = self.kernel.client()
-        self.client.start_channels()
+        self.manager = KernelManager(kernel_name='python3')
         working_directory = misc.option("execute_working_directory=", None)
         if working_directory is not None:
-            print("CHANGING DIRECTORY", working_directory)
-            run_cell(self, "import os; os.chdir('{}')".format(working_directory))
+            self.kernel = self.manager.start_kernel(cwd=working_directory)
+        else:
+            self.kernel = self.manager.start_kernel()
+        self.client = self.manager.client()
+        self.client.start_channels()
 
 def stop(kernel_client):
     kernel_client.client.stop_channels()
-    kernel_client.manager.shutdown_kernel(kernel_client.kernel_id)
+    kernel_client.manager.shutdown_kernel()
 
 
 def run_cell(kernel_client, source, timeout=120):

--- a/lib/doconce/execution.py
+++ b/lib/doconce/execution.py
@@ -10,11 +10,7 @@ except ImportError:
 class JupyterKernelClient:
     def __init__(self):
         self.manager = KernelManager(kernel_name='python3')
-        working_directory = misc.option("execute_working_directory=", None)
-        if working_directory is not None:
-            self.kernel = self.manager.start_kernel(cwd=working_directory)
-        else:
-            self.kernel = self.manager.start_kernel()
+        self.kernel = self.manager.start_kernel()
         self.client = self.manager.client()
         self.client.start_channels()
 

--- a/lib/doconce/execution.py
+++ b/lib/doconce/execution.py
@@ -27,7 +27,6 @@ def run_cell(kernel_client, source, timeout=120):
     # Adapted from nbconvert.ExecutePreprocessor
     # Copyright (c) IPython Development Team.
     # Distributed under the terms of the Modified BSD License.
-
     msg_id = kernel_client.client.execute(source)
     # wait for finish, with timeout
     while True:

--- a/lib/doconce/execution.py
+++ b/lib/doconce/execution.py
@@ -17,7 +17,7 @@ def stop(kernel_client):
     kernel_client.client.stop_channels()
     kernel_client.manager.shutdown_kernel(kernel_client.kernel_id)
 
-def run_cell(kernel_client, source, timeout=30, cell_index=0):
+def run_cell(kernel_client, source, timeout=120, cell_index=0):
     # Adapted from nbconvert.ExecutePreprocessor
     # Copyright (c) IPython Development Team.
     # Distributed under the terms of the Modified BSD License.
@@ -61,7 +61,6 @@ def run_cell(kernel_client, source, timeout=30, cell_index=0):
             continue
 
         msg_type = msg['msg_type']
-        print("output:", msg_type)
         content = msg['content']
 
         # set the prompt number for the input and the output

--- a/lib/doconce/execution.py
+++ b/lib/doconce/execution.py
@@ -19,7 +19,6 @@ def run_cell(kernel_client, source, timeout=30, cell_index=0):
     # Distributed under the terms of the Modified BSD License.
     
     msg_id = kernel_client.execute(source)
-    print("Executing cell:\n", source)
     # wait for finish, with timeout
     while True:
         try:

--- a/lib/doconce/execution.py
+++ b/lib/doconce/execution.py
@@ -1,0 +1,108 @@
+from jupyter_client import MultiKernelManager
+from nbformat.v4 import output_from_msg
+try:
+    from queue import Empty  # Py 3
+except ImportError:
+    from Queue import Empty # Py 2
+
+def create_kernel_client():
+    kernelmanager = MultiKernelManager()
+    kernel_client_id = kernelmanager.start_kernel('python3')
+    kernel_client_kernel = kernelmanager.get_kernel(kernel_client_id)
+    kernel_client = kernel_client_kernel.client()
+    kernel_client.start_channels()
+    return kernel_client
+
+def run_cell(kernel_client, source, timeout=30, cell_index=0):
+    # Adapted from nbconvert.ExecutePreprocessor
+    # Copyright (c) IPython Development Team.
+    # Distributed under the terms of the Modified BSD License.
+    
+    msg_id = kernel_client.execute(source)
+    print("Executing cell:\n", source)
+    # wait for finish, with timeout
+    while True:
+        try:
+            msg = kernel_client.shell_channel.get_msg(timeout=timeout)
+        except Empty:
+            print("Timeout waiting for execute reply", timeout)
+            try:
+                exception = TimeoutError
+            except NameError:
+                exception = RuntimeError
+            raise exception("Cell execution timed out")
+
+        if msg['parent_header'].get('msg_id') == msg_id:
+            break
+        else:
+            # not our reply
+            continue
+
+    outs = []
+    execution_count = None
+
+    while True:
+        try:
+            # We've already waited for execute_reply, so all output
+            # should already be waiting. However, on slow networks, like
+            # in certain CI systems, waiting < 1 second might miss messages.
+            # So long as the kernel sends a status:idle message when it
+            # finishes, we won't actually have to wait this long, anyway.
+            msg = kernel_client.iopub_channel.get_msg(timeout=5)
+        except Empty:
+            print("Timeout waiting for IOPub output")
+            break
+        if msg['parent_header'].get('msg_id') != msg_id:
+            # not an output from our execution
+            continue
+
+        msg_type = msg['msg_type']
+        print("output:", msg_type)
+        content = msg['content']
+
+        # set the prompt number for the input and the output
+        if 'execution_count' in content:
+            execution_count = content['execution_count']
+            # cell['execution_count'] = content['execution_count']
+
+        if msg_type == 'status':
+            if content['execution_state'] == 'idle':
+                break
+            else:
+                continue
+        elif msg_type == 'execute_input':
+            continue
+        elif msg_type == 'clear_output':
+            outs[:] = []
+            # clear display_id mapping for this cell
+            # for display_id, cell_map in self._display_id_map.items():
+            #     if cell_index in cell_map:
+            #         cell_map[cell_index] = []
+            continue
+        elif msg_type.startswith('comm'):
+            continue
+        
+        display_id = None
+        if msg_type in {'execute_result', 'display_data', 'update_display_data'}:
+            display_id = msg['content'].get('transient', {}).get('display_id', None)
+            # if display_id:
+                # self._update_display_id(display_id, msg)
+            if msg_type == 'update_display_data':
+                # update_display_data doesn't get recorded
+                continue
+
+        try:
+            out = output_from_msg(msg)
+        except ValueError:
+            print("unhandled iopub msg: " + msg_type)
+            continue
+        # if display_id:
+            # record output index in:
+            #   _display_id_map[display_id][cell_idx]
+            # cell_map = self._display_id_map.setdefault(display_id, {})
+            # output_idx_list = cell_map.setdefault(cell_index, [])
+            # output_idx_list.append(len(outs))
+
+        outs.append(out)
+
+    return outs, execution_count

--- a/lib/doconce/ipynb.py
+++ b/lib/doconce/ipynb.py
@@ -614,7 +614,8 @@ def ipynb_code(filestr, code_blocks, code_block_types,
     mdstr = []  # plain md format of the notebook
     prompt_number = 1
     
-    kernel_client = execution.JupyterKernelClient()
+    if option("execute"):
+        kernel_client = execution.JupyterKernelClient()
     
     for block_tp, block in notebook_blocks:
         if (block_tp == 'text' or block_tp == 'math') and block != '' and block != '<!--  -->':

--- a/lib/doconce/ipynb.py
+++ b/lib/doconce/ipynb.py
@@ -9,6 +9,11 @@ from .pandoc import pandoc_ref_and_label, pandoc_index_bib, pandoc_quote, \
      language2pandoc, pandoc_quiz
 from .misc import option, _abort
 from .doconce import errwarn
+from nbformat.v4 import output_from_msg
+try:
+    from queue import Empty  # Py 3
+except ImportError:
+    from Queue import Empty # Py 2
 
 # Global variables
 figure_encountered = False
@@ -242,6 +247,99 @@ video_tag = '<video controls loop alt="%s" height="%s" width="%s" src="data:vide
         _abort()
     text += '<!-- end movie -->\n'
     return text
+    
+
+def run_cell(kc, cell, timeout=30, cell_index=0):
+    # Adapted from nbconvert.ExecutePreprocessor
+    # Copyright (c) IPython Development Team.
+    # Distributed under the terms of the Modified BSD License.
+    
+    msg_id = kc.execute(cell.source)
+    print("Executing cell:\n%s", cell.source)
+    # wait for finish, with timeout
+    while True:
+        try:
+            msg = kc.shell_channel.get_msg(timeout=timeout)
+        except Empty:
+            print("Timeout waiting for execute reply", timeout)
+            try:
+                exception = TimeoutError
+            except NameError:
+                exception = RuntimeError
+            raise exception("Cell execution timed out")
+
+        if msg['parent_header'].get('msg_id') == msg_id:
+            break
+        else:
+            # not our reply
+            continue
+
+    outs = cell.outputs = []
+
+    while True:
+        try:
+            # We've already waited for execute_reply, so all output
+            # should already be waiting. However, on slow networks, like
+            # in certain CI systems, waiting < 1 second might miss messages.
+            # So long as the kernel sends a status:idle message when it
+            # finishes, we won't actually have to wait this long, anyway.
+            msg = kc.iopub_channel.get_msg(timeout=5)
+        except Empty:
+            print("Timeout waiting for IOPub output")
+            break
+        if msg['parent_header'].get('msg_id') != msg_id:
+            # not an output from our execution
+            continue
+
+        msg_type = msg['msg_type']
+        print("output:", msg_type)
+        content = msg['content']
+
+        # set the prompt number for the input and the output
+        if 'execution_count' in content:
+            cell['execution_count'] = content['execution_count']
+
+        if msg_type == 'status':
+            if content['execution_state'] == 'idle':
+                break
+            else:
+                continue
+        elif msg_type == 'execute_input':
+            continue
+        elif msg_type == 'clear_output':
+            outs[:] = []
+            # clear display_id mapping for this cell
+            # for display_id, cell_map in self._display_id_map.items():
+            #     if cell_index in cell_map:
+            #         cell_map[cell_index] = []
+            continue
+        elif msg_type.startswith('comm'):
+            continue
+        
+        display_id = None
+        if msg_type in {'execute_result', 'display_data', 'update_display_data'}:
+            display_id = msg['content'].get('transient', {}).get('display_id', None)
+            # if display_id:
+                # self._update_display_id(display_id, msg)
+            if msg_type == 'update_display_data':
+                # update_display_data doesn't get recorded
+                continue
+
+        try:
+            out = output_from_msg(msg)
+        except ValueError:
+            print("unhandled iopub msg: " + msg_type)
+            continue
+        # if display_id:
+            # record output index in:
+            #   _display_id_map[display_id][cell_idx]
+            # cell_map = self._display_id_map.setdefault(display_id, {})
+            # output_idx_list = cell_map.setdefault(cell_index, [])
+            # output_idx_list.append(len(outs))
+
+        outs.append(out)
+
+    return outs
 
 def ipynb_code(filestr, code_blocks, code_block_types,
                tex_blocks, format):
@@ -445,6 +543,8 @@ def ipynb_code(filestr, code_blocks, code_block_types,
             ipynb_code_tp[i] = 'cell_hidden'
         elif tp.endswith('out'):
             ipynb_code_tp[i] = 'cell_output'
+        elif tp.endswith('cell'):
+            ipynb_code_tp[i] = 'cell_autoexecute'
         elif tp.startswith('py'):
             ipynb_code_tp[i] = 'cell'
         else:
@@ -502,6 +602,8 @@ def ipynb_code(filestr, code_blocks, code_block_types,
             idx = int(m.group(1))
             if ipynb_code_tp[idx] == 'cell':
                 notebook_blocks[i] = ['cell', notebook_blocks[i]]
+            elif ipynb_code_tp[idx] == 'cell_autoexecute':
+                notebook_blocks[i] = ['cell_autoexecute', notebook_blocks[i]]
             elif ipynb_code_tp[idx] == 'cell_hidden':
                 notebook_blocks[i] = ['cell_hidden', notebook_blocks[i]]
             elif ipynb_code_tp[idx] == 'cell_output':
@@ -607,6 +709,16 @@ def ipynb_code(filestr, code_blocks, code_block_types,
 
     mdstr = []  # plain md format of the notebook
     prompt_number = 1
+    
+    # Prepare Autoexecute
+    from jupyter_client import MultiKernelManager
+    kernelmanager = MultiKernelManager()
+    remote_id = kernelmanager.start_kernel('python3')
+    remote_kernel = kernelmanager.get_kernel(remote_id)
+    remote = remote_kernel.client()
+    remote.start_channels()
+    # end prepare autoexecute
+    
     for block_tp, block in notebook_blocks:
         if (block_tp == 'text' or block_tp == 'math') and block != '' and block != '<!--  -->':
             if nb_version == 3:
@@ -615,37 +727,45 @@ def ipynb_code(filestr, code_blocks, code_block_types,
                 cells.append(new_markdown_cell(source=block))
             mdstr.append(('markdown', block))
         elif block_tp == 'cell' and block != '' and block != []:
-            if isinstance(block, list):
-                for block_ in block:
-                    block_ = block_.rstrip()
-                    if block_ != '':
-                        if nb_version == 3:
-                            nb.cells.append(new_code_cell(
-                                input=block_,
-                                prompt_number=prompt_number,
-                                collapsed=False))
-                        elif nb_version == 4:
-                            cells.append(new_code_cell(
-                                source=block_,
-                                execution_count=prompt_number,
-                                metadata=dict(collapsed=False)))
-                        prompt_number += 1
-                        mdstr.append(('codecell', block_))
-            else:
-                block = block.rstrip()
-                if block != '':
+            if not isinstance(block, list):
+                block = [block]
+            for block_ in block:
+                block_ = block_.rstrip()
+                if block_ != '':
                     if nb_version == 3:
                         nb.cells.append(new_code_cell(
-                            input=block,
+                            input=block_,
                             prompt_number=prompt_number,
                             collapsed=False))
                     elif nb_version == 4:
                         cells.append(new_code_cell(
-                            source=block,
+                            source=block_,
                             execution_count=prompt_number,
                             metadata=dict(collapsed=False)))
                     prompt_number += 1
-                    mdstr.append(('codecell', block))
+                    mdstr.append(('codecell', block_))
+        elif block_tp == 'cell_autoexecute':            
+            print("Got cell autoexec!!!!")
+            timeout = 30
+            if nb_version == 3:
+                print("WARNING: Autoexecute not implemented for nbformat v3.")
+                continue
+            if not isinstance(block, list):
+                block = [block]
+            for block_ in block:
+                block_ = block_.rstrip()
+                if block_ != '':
+                    code_cell = new_code_cell(
+                        source=block_,
+                        execution_count=prompt_number,
+                        metadata=dict(collapsed=False)
+                    )
+                    cells.append(code_cell)
+                    prompt_number += 1
+                    mdstr.append(('codecell', block_))
+                    
+                    code_cell.outputs = run_cell(remote, code_cell)
+                    
         elif block_tp == 'cell_output' and block != '':
             block = block.rstrip()
             if nb_version == 3:

--- a/lib/doconce/ipynb.py
+++ b/lib/doconce/ipynb.py
@@ -613,10 +613,10 @@ def ipynb_code(filestr, code_blocks, code_block_types,
 
     mdstr = []  # plain md format of the notebook
     prompt_number = 1
-    
+
     if option("execute"):
         kernel_client = execution.JupyterKernelClient()
-    
+
     for block_tp, block in notebook_blocks:
         if (block_tp == 'text' or block_tp == 'math') and block != '' and block != '<!--  -->':
             if nb_version == 3:
@@ -846,8 +846,9 @@ def ipynb_index_bib(filestr, index, citations, pubfile, pubdata):
                      filestr, flags=re.MULTILINE)
     return filestr
 
-
 def ipynb_ref_and_label(section_label2title, format, filestr):
+    # TODO: comments should have been removed before we get here!
+    filestr = re.sub(r'^#.+', '', filestr, flags=re.MULTILINE)
     filestr = fix_ref_section_chapter(filestr, format)
 
     # Replace all references to sections. Pandoc needs a coding of

--- a/lib/doconce/ipynb.py
+++ b/lib/doconce/ipynb.py
@@ -614,7 +614,7 @@ def ipynb_code(filestr, code_blocks, code_block_types,
     mdstr = []  # plain md format of the notebook
     prompt_number = 1
     
-    kernel_client = execution.create_kernel_client()
+    kernel_client = execution.JupyterKernelClient()
     
     for block_tp, block in notebook_blocks:
         if (block_tp == 'text' or block_tp == 'math') and block != '' and block != '<!--  -->':
@@ -792,6 +792,8 @@ def ipynb_code(filestr, code_blocks, code_block_types,
  ]
 }"""
     '''
+    execution.stop(kernel_client)
+    
     return filestr
 
 def ipynb_index_bib(filestr, index, citations, pubfile, pubdata):

--- a/lib/doconce/ipynb.py
+++ b/lib/doconce/ipynb.py
@@ -649,7 +649,7 @@ def ipynb_code(filestr, code_blocks, code_block_types,
                                 cell["execution_count"] = execution_count
                     prompt_number += 1
                     mdstr.append(('codecell', block_))
-        elif block_tp == 'cell_output' and block != '':
+        elif block_tp == 'cell_output' and block != '' and not option("ignore_output"):
             block = block.rstrip()
             if nb_version == 3:
                 print("WARNING: Output not implemented for nbformat v3.")

--- a/lib/doconce/ipynb.py
+++ b/lib/doconce/ipynb.py
@@ -793,7 +793,8 @@ def ipynb_code(filestr, code_blocks, code_block_types,
  ]
 }"""
     '''
-    execution.stop(kernel_client)
+    if option("execute"):
+        execution.stop(kernel_client)
     
     return filestr
 

--- a/lib/doconce/latex.py
+++ b/lib/doconce/latex.py
@@ -1057,7 +1057,6 @@ def latex_code(filestr, code_blocks, code_block_types,
                 errwarn('*** error: mismatch between !bc and !ec')
                 errwarn('\n'.join(lines[i-3:i+4]))
                 _abort()
-            print("FORMATTING", current_code_envir, latex_code_style)
             if latex_code_style is None:
                 lines[i] = '\\b' + current_code_envir
             else:

--- a/lib/doconce/latex.py
+++ b/lib/doconce/latex.py
@@ -100,6 +100,7 @@ envir2lst = dict(
 def latex_code_envir(envir, envir_spec):
     if envir_spec is None:
         return '\\b' + envir, '\\e' + envir
+        
     leftmargin = option('latex_code_leftmargin=', '2')
     bg_vpad = '_vpad' if option('latex_code_bg_vpad') else ''
 
@@ -217,7 +218,7 @@ def interpret_latex_code_style():
             envir, pkg = pkg.split(':')
         return pkg, bg, style
 
-    legal_envirs = 'pro pypro cypro cpppro cpro fpro plpro shpro mpro cod pycod cycod cppcod ccod fcod plcod shcod mcod rst cppans pyans fans bashans swigans uflans sni dat dsni sys slin ipy pyshell rpy plin ver warn rule summ ccq cc ccl txt htmlcod htmlpro html rbpro rbcod rb xmlpro xmlcod xml latexpro latexcod latex default'.split()
+    legal_envirs = 'pro pypro pyout cypro cpppro cpro fpro plpro shpro mpro cod pycod cycod cppcod ccod fcod plcod shcod mcod rst cppans pyans fans bashans swigans uflans sni dat dsni sys slin ipy pyshell rpy plin ver warn rule summ ccq cc ccl txt htmlcod htmlpro html rbpro rbcod rb xmlpro xmlcod xml latexpro latexcod latex default'.split()
     d = {}
     if '@' not in latex_code_style:
         # Common definition for all languages
@@ -582,7 +583,7 @@ def latex_code(filestr, code_blocks, code_block_types,
     filestr = safe_join(lines, '\n')
 
     # Check for misspellings
-    envirs = 'pro pypro cypro cpppro cpro fpro plpro shpro mpro cod pycod cycod cppcod ccod fcod plcod shcod mcod htmlcod htmlpro latexcod latexpro rstcod rstpro xmlcod xmlpro cppans pyans fans bashans swigans uflans sni dat dsni csv txt sys slin ipy rpy plin ver warn rule summ ccq cc ccl pyshell pyoptpro pyscpro ipy do'.split()
+    envirs = 'pro pypro pyout cypro cpppro cpro fpro plpro shpro mpro cod pycod cycod cppcod ccod fcod plcod shcod mcod htmlcod htmlpro latexcod latexpro rstcod rstpro xmlcod xmlpro cppans pyans fans bashans swigans uflans sni dat dsni csv txt sys slin ipy rpy plin ver warn rule summ ccq cc ccl pyshell pyoptpro pyscpro ipy do'.split()
     
     for i, envir in enumerate(code_block_types):
         if envir.endswith("-t"):
@@ -1069,6 +1070,9 @@ def latex_code(filestr, code_blocks, code_block_types,
                 errwarn('*** error: mismatch between !bc and !ec')
                 errwarn('\n'.join(lines[i-3:i+4]))
                 _abort()
+            if current_code_envir.endswith("out") and option("ignore_output"):
+                lines[i] = ""
+                continue
             begin, end = latex_code_envir(
                 current_code_envir,
                 latex_code_style
@@ -1085,13 +1089,15 @@ def latex_code(filestr, code_blocks, code_block_types,
                 #errwarn('    check that every !bc matches !ec in the entire text:')
                 #errwarn(filestr)
                 _abort()
-            
             begin, end = latex_code_envir(
                 current_code_envir,    
                 latex_code_style
             )
-            lines [i] = end
-            if option("execute") and not current_code_envir.endswith("-t"):
+            if current_code_envir.endswith("out") and option("ignore_output"):
+                lines[i] = ""
+            else:
+                lines [i] = end
+            if option("execute") and not current_code_envir.endswith("-t") and not current_code_envir.endswith("out"):
                 outputs, execution_count = execution.run_cell(kernel_client, current_code)
                 if len(outputs) > 0:
                     for output in outputs:
@@ -1132,6 +1138,9 @@ def latex_code(filestr, code_blocks, code_block_types,
             current_code = ""
         else:
             if current_code_envir is not None:
+                if current_code_envir.endswith("out") and option("ignore_output"):
+                    lines[i] = ""
+                    continue
                 current_code += lines[i] + "\n"
                 
     if option("execute"):

--- a/lib/doconce/latex.py
+++ b/lib/doconce/latex.py
@@ -588,6 +588,8 @@ def latex_code(filestr, code_blocks, code_block_types,
     for i, envir in enumerate(code_block_types):
         if envir.endswith("-t"):
             code_block_types[i] = re.sub(r"-t$", "", envir)
+        if envir.endswith("-e"):
+            code_block_types[i] = re.sub(r"-e$", "", envir)
     
     # Add user's potential new envirs inside admons
     new_envirs = []
@@ -1073,6 +1075,9 @@ def latex_code(filestr, code_blocks, code_block_types,
             if current_code_envir.endswith("out") and option("ignore_output"):
                 lines[i] = ""
                 continue
+            elif current_code_envir.endswith("-e"):
+                lines[i] = ""
+                continue
             begin, end = latex_code_envir(
                 current_code_envir,
                 latex_code_style
@@ -1095,9 +1100,13 @@ def latex_code(filestr, code_blocks, code_block_types,
             )
             if current_code_envir.endswith("out") and option("ignore_output"):
                 lines[i] = ""
+            elif current_code_envir.endswith("-e"):
+                if option("execute"):
+                    execution.run_cell(kernel_client, current_code)
+                lines[i] = ""
             else:
                 lines [i] = end
-            if option("execute") and not current_code_envir.endswith("-t") and not current_code_envir.endswith("out"):
+            if option("execute") and not current_code_envir.endswith("-t") and not current_code_envir.endswith("out") and not current_code_envir.endswith("-e"):
                 outputs, execution_count = execution.run_cell(kernel_client, current_code)
                 if len(outputs) > 0:
                     ansi_escape = re.compile(r'\x1b[^m]*m')
@@ -1154,6 +1163,8 @@ def latex_code(filestr, code_blocks, code_block_types,
                     lines[i] = ""
                     continue
                 current_code += lines[i] + "\n"
+                if current_code_envir.endswith("-e"):
+                    lines[i] = ""
                 
     if option("execute"):
         execution.stop(kernel_client)

--- a/lib/doconce/latex.py
+++ b/lib/doconce/latex.py
@@ -7,6 +7,7 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import zip
 from builtins import str
+from builtins import bytes
 from builtins import range
 from past.utils import old_div
 import os, subprocess, re, sys, glob, shutil, subprocess

--- a/lib/doconce/latex.py
+++ b/lib/doconce/latex.py
@@ -1091,7 +1091,6 @@ def latex_code(filestr, code_blocks, code_block_types,
                 latex_code_style
             )
             lines [i] = end
-            print("Code envir", current_code_envir)
             if option("execute") and not current_code_envir.endswith("-t"):
                 outputs, execution_count = execution.run_cell(kernel_client, current_code)
                 if len(outputs) > 0:
@@ -1135,7 +1134,8 @@ def latex_code(filestr, code_blocks, code_block_types,
             if current_code_envir is not None:
                 current_code += lines[i] + "\n"
                 
-    execution.stop(kernel_client)
+    if option("execute"):
+        execution.stop(kernel_client)
     
     filestr = safe_join(lines, '\n')
 

--- a/lib/doconce/latex.py
+++ b/lib/doconce/latex.py
@@ -583,6 +583,11 @@ def latex_code(filestr, code_blocks, code_block_types,
 
     # Check for misspellings
     envirs = 'pro pypro cypro cpppro cpro fpro plpro shpro mpro cod pycod cycod cppcod ccod fcod plcod shcod mcod htmlcod htmlpro latexcod latexpro rstcod rstpro xmlcod xmlpro cppans pyans fans bashans swigans uflans sni dat dsni csv txt sys slin ipy rpy plin ver warn rule summ ccq cc ccl pyshell pyoptpro pyscpro ipy do'.split()
+    
+    for i, envir in enumerate(code_block_types):
+        if envir.endswith("-t"):
+            code_block_types[i] = re.sub(r"-t$", "", envir)
+    
     # Add user's potential new envirs inside admons
     new_envirs = []
     for envir in envirs:
@@ -1079,7 +1084,8 @@ def latex_code(filestr, code_blocks, code_block_types,
                 latex_code_style
             )
             lines [i] = end
-            if option("execute"):
+            print("Code envir", current_code_envir)
+            if option("execute") and not current_code_envir.endswith("-t"):
                 outputs, execution_count = execution.run_cell(kernel_client, current_code)
                 if len(outputs) > 0:
                     for output in outputs:

--- a/lib/doconce/latex.py
+++ b/lib/doconce/latex.py
@@ -1131,8 +1131,10 @@ def latex_code(filestr, code_blocks, code_block_types,
                                 else:
                                     img_data = data["image/png"]
                                     suffix = ".png"
-                                filename_stem = ".doconce_figure_cache/{}".format(str(uuid.uuid4()))
-                                os.makedirs(".doconce_figure_cache", exist_ok=True)
+                                cache_folder = ".doconce_figure_cache"
+                                filename_stem = "{}/{}".format(cache_folder, str(uuid.uuid4()))
+                                if not os.path.exists(cache_folder):
+                                    os.makedirs(cache_folder)
                                 filename = "{}{}".format(filename_stem, suffix)
                                 g = open(filename, "wb")
                                 g.write(base64.decodebytes(bytes(img_data, encoding="utf-8")))

--- a/lib/doconce/misc.py
+++ b/lib/doconce/misc.py
@@ -615,6 +615,8 @@ the document into multiple parts."""),
      'Combine paragraphs to one line (does not work well).'),
     ('--execute',
      'Automatically run code blocks and show output below the code block.'),
+    ('--ignore_output',
+     'Ignore output cells. Useful when you want to use execute rather than predefined output cells.'),
     ]
 
 _legal_command_line_options = \

--- a/lib/doconce/misc.py
+++ b/lib/doconce/misc.py
@@ -613,6 +613,8 @@ the document into multiple parts."""),
     ('--sphinx_figure_captions=', 'Font style in figure captions: emphasize (default) or normal. If you use boldface or emphasize in the caption, the font style will be normal for that caption.'),
     ('--oneline_paragraphs',
      'Combine paragraphs to one line (does not work well).'),
+    ('--execute',
+     'Automatically run code blocks and show output below the code block.'),
     ]
 
 _legal_command_line_options = \

--- a/lib/doconce/misc.py
+++ b/lib/doconce/misc.py
@@ -615,8 +615,6 @@ the document into multiple parts."""),
      'Combine paragraphs to one line (does not work well).'),
     ('--execute',
      'Automatically run code blocks and show output below the code block.'),
-    ('--execute_working_directory=',
-     'Set the working directory for running code.'),
     ('--ignore_output',
      'Ignore output cells. Useful when you want to use execute rather than predefined output cells.'),
     ]

--- a/lib/doconce/misc.py
+++ b/lib/doconce/misc.py
@@ -615,6 +615,8 @@ the document into multiple parts."""),
      'Combine paragraphs to one line (does not work well).'),
     ('--execute',
      'Automatically run code blocks and show output below the code block.'),
+    ('--execute_working_directory=',
+     'Set the working directory for running code.'),
     ('--ignore_output',
      'Ignore output cells. Useful when you want to use execute rather than predefined output cells.'),
     ]

--- a/test/execute.do.txt
+++ b/test/execute.do.txt
@@ -1,5 +1,11 @@
 ======= Automatic execution of code blocks =======
 
+Compile this document with
+
+!bc sh-t
+doconce format execute.do.txt --execute
+!ec
+
 Hidden execution cells can be used to perform operations that need to be done
 before the following cells are executed:
 
@@ -82,18 +88,18 @@ with open("../LICENSE") as f:
     print(f.read())
 !ec
 
-=== References ===
-
-If you want to reference a generated figure or code block, just use label and ref:
-
-!bc pycod
-from pylab import *
-
-x = linspace(0, 10, 100)
-plot(x, x*x)
-show()
-!ec
-label{fig:myplot}
-
-We will now refer to it as Figure ref{fig:myplot} and return to more information about
-the figure.
+# === References ===
+# 
+# If you want to reference a generated figure or code block, just use label and ref:
+# 
+# !bc pycod
+# from pylab import *
+# 
+# x = linspace(0, 10, 100)
+# plot(x, x*x)
+# show()
+# !ec
+# label{fig:myplot}
+# 
+# We will now refer to it as Figure ref{fig:myplot} and return to more information about
+# the figure.

--- a/test/execute.do.txt
+++ b/test/execute.do.txt
@@ -1,4 +1,4 @@
-======= Automatic execution of code blocks =======
+========= Automatic execution of code blocks =========
 
 Compile this document with
 
@@ -26,7 +26,7 @@ print("The result is {}".format(c))
 c
 !ec
 
-=== Plotting ===
+======= Plotting =======
 
 This is a cell that should plot and output:
 
@@ -45,7 +45,7 @@ from IPython.display import set_matplotlib_formats
 set_matplotlib_formats('png', 'pdf')
 !ec
 
-=== Ignore output ===
+======= Ignore output =======
 
 Predefined output can be omitted by passing `--ignore_output` to DocOnce.
 This will remove all environments ending with `out`.
@@ -59,7 +59,7 @@ print(a)
 2
 !ec
 
-=== Not executed ===
+======= Not executed =======
 
 This is a code block that should not be executed:
 
@@ -71,7 +71,7 @@ while True:
 This is some *formatted* stuff, which is _underlined_ and stuff and maybe even
 contains $a + 2b$.
 
-=== Code with errors ===
+======= Code with errors =======
 
 If code contains errors, it will still be run and the exception shown as part
 of the output:
@@ -81,25 +81,12 @@ for a in range(10)
     print(a)
 !ec
 
-=== Open file ===
+======= Opening files =======
+
+The working directory is the same as the .do.txt file.
+You may want to use `os.chdir` to change the directory.
 
 !bc pycod
 with open("../LICENSE") as f:
     print(f.read())
 !ec
-
-# === References ===
-# 
-# If you want to reference a generated figure or code block, just use label and ref:
-# 
-# !bc pycod
-# from pylab import *
-# 
-# x = linspace(0, 10, 100)
-# plot(x, x*x)
-# show()
-# !ec
-# label{fig:myplot}
-# 
-# We will now refer to it as Figure ref{fig:myplot} and return to more information about
-# the figure.

--- a/test/execute.do.txt
+++ b/test/execute.do.txt
@@ -1,4 +1,4 @@
-======= Testing pycell =======
+======= Automatic execution of code blocks =======
 
 Hidden execution cells can be used to perform operations that need to be done
 before the following cells are executed:
@@ -81,3 +81,19 @@ for a in range(10)
 with open("../LICENSE") as f:
     print(f.read())
 !ec
+
+=== References ===
+
+If you want to reference a generated figure or code block, just use label and ref:
+
+!bc pycod
+from pylab import *
+
+x = linspace(0, 10, 100)
+plot(x, x*x)
+show()
+!ec
+label{fig:myplot}
+
+We will now refer to it as Figure ref{fig:myplot} and return to more information about
+the figure.

--- a/test/pycell.do.txt
+++ b/test/pycell.do.txt
@@ -29,6 +29,20 @@ from IPython.display import set_matplotlib_formats
 set_matplotlib_formats('png', 'pdf')
 !ec
 
+=== Ignore output ===
+
+Output from `pyout` and similar can be ignored by passing `--ignore_output` to
+DocOnce:
+
+!bc pycod
+a = 2
+print(a)
+!ec
+
+!bc pyout 
+2
+!ec
+
 === Not executed ===
 
 This is a code block that should not be executed:

--- a/test/pycell.do.txt
+++ b/test/pycell.do.txt
@@ -1,9 +1,19 @@
 ======= Testing pycell =======
 
+Hidden execution cells can be used to perform operations that need to be done
+before the following cells are executed:
+
+!bc pycod-e
+import os
+os.listdir(".")
+a = 1
+e = 0
+f = 3
+!ec
+
 This is a cell that should execute automatically:
 
 !bc pycod
-a = 1
 b = 2
 c = a + b
 print("The result is {}".format(c))

--- a/test/pycell.do.txt
+++ b/test/pycell.do.txt
@@ -64,3 +64,10 @@ of the output:
 for a in range(10)
     print(a)
 !ec
+
+=== Open file ===
+
+!bc pycod
+with open("../LICENSE") as f:
+    print(f.read())
+!ec

--- a/test/pycell.do.txt
+++ b/test/pycell.do.txt
@@ -2,7 +2,7 @@
 
 This is a cell that should execute automatically:
 
-!bc pycell
+!bc pycod
 a = 1
 b = 2
 c = a + b
@@ -12,7 +12,7 @@ c
 
 This is a cell that should plot and output:
 
-!bc pycell
+!bc pycod
 from pylab import *
 x = linspace(0, 10, 100)
 plot(x, x*x)

--- a/test/pycell.do.txt
+++ b/test/pycell.do.txt
@@ -18,3 +18,8 @@ x = linspace(0, 10, 100)
 plot(x, x*x)
 show()
 !ec
+
+!bc pycod-t
+while True:
+    i = 2
+!ec

--- a/test/pycell.do.txt
+++ b/test/pycell.do.txt
@@ -31,8 +31,8 @@ set_matplotlib_formats('png', 'pdf')
 
 === Ignore output ===
 
-Output from `pyout` and similar can be ignored by passing `--ignore_output` to
-DocOnce:
+Predefined output can be omitted by passing `--ignore_output` to DocOnce.
+This will remove all environments ending with `out`.
 
 !bc pycod
 a = 2
@@ -54,3 +54,13 @@ while True:
 
 This is some *formatted* stuff, which is _underlined_ and stuff and maybe even
 contains $a + 2b$.
+
+=== Code with errors ===
+
+If code contains errors, it will still be run and the exception shown as part
+of the output:
+
+!bc pycod
+for a in range(10)
+    print(a)
+!ec

--- a/test/pycell.do.txt
+++ b/test/pycell.do.txt
@@ -10,6 +10,8 @@ print("The result is {}".format(c))
 c
 !ec
 
+=== Plotting ===
+
 This is a cell that should plot and output:
 
 !bc pycod
@@ -19,7 +21,22 @@ plot(x, x*x)
 show()
 !ec
 
+To improve quality when exporting to LaTeX, the following code has automatically
+been run to enable PDF export in notebooks.
+
+!bc pycod-t
+from IPython.display import set_matplotlib_formats
+set_matplotlib_formats('png', 'pdf')
+!ec
+
+=== Not executed ===
+
+This is a code block that should not be executed:
+
 !bc pycod-t
 while True:
     i = 2
 !ec
+
+This is some *formatted* stuff, which is _underlined_ and stuff and maybe even
+contains $a + 2b$.

--- a/test/pycell.do.txt
+++ b/test/pycell.do.txt
@@ -1,0 +1,20 @@
+======= Testing pycell =======
+
+This is a cell that should execute automatically:
+
+!bc pycell
+a = 1
+b = 2
+c = a + b
+print("The result is {}".format(c))
+c
+!ec
+
+This is a cell that should plot and output:
+
+!bc pycell
+from pylab import *
+x = linspace(0, 10, 100)
+plot(x, x*x)
+show()
+!ec


### PR DESCRIPTION
This adds support for automatically executing code cells using the --execute option. Specific code blocks can be run without appearing in the document by adding -e to the code block definition. Code blocks defined specifically as text with -t are not run.

# Limitiations # 

- Currently assumes all blocks to be Python 3
- Runs all cells in the same kernel, no support for restarting or resetting the kernel