### PR TITLE
added new ipynb_cite option that emulates latex plain style citations

### DIFF
--- a/lib/doconce/doconce.py
+++ b/lib/doconce/doconce.py
@@ -3392,7 +3392,7 @@ def handle_index_and_bib(filestr, format):
                 if format in ('latex', 'pdflatex'):
                     cite_formatting = 'latex'
                 elif format in ('pandoc', 'ipynb'):
-                    if option('ipynb_cite=', 'plain') == 'latex':
+                    if option('ipynb_cite=', 'plain') in ('latex', 'latex-plain'):
                         cite_formatting = 'standard'
                     else:
                         cite_formatting = 'pandoc'

--- a/lib/doconce/ipynb.py
+++ b/lib/doconce/ipynb.py
@@ -866,7 +866,9 @@ def ipynb_index_bib_latex_plain(filestr, index, citations, pubfile, pubdata):
 
     # Save idx{} and label{} as metadata, also have labels as div tags
     filestr = re.sub(r'(idx\{.+?\})', r'<!-- dom:\g<1> -->', filestr)
-    filestr = re.sub(r'(label\{(.+?)\})', r'<!-- dom:\g<1> --><div id="\g<2>"></div>', filestr)
+    # filestr = re.sub(r'(label\{(.+?)\})', r'<!-- dom:\g<1> --><div id="\g<2>"></div>', filestr)
+    filestr = re.sub(r'label\{(.+?)\}', '<div id="\g<1>"></div>', filestr)
+
     # Also treat special cell delimiter comments that might appear from
     # doconce ipynb2doconce conversions
     filestr = re.sub(r'^# ---------- (markdown|code) cell$', '',

--- a/lib/doconce/ipynb.py
+++ b/lib/doconce/ipynb.py
@@ -864,15 +864,16 @@ def ipynb_index_bib_latex_plain(filestr, index, citations, pubfile, pubdata):
         bibtext = bibliography(pubdata, citations, format='doconce')
         filestr = re.sub(r'^BIBFILE:.+$', bibtext, filestr, flags=re.MULTILINE)
 
-    # Save idx{} and label{} as metadata, also have labels as div tags
-    filestr = re.sub(r'(idx\{.+?\})', r'<!-- dom:\g<1> -->', filestr)
-    # filestr = re.sub(r'(label\{(.+?)\})', r'<!-- dom:\g<1> --><div id="\g<2>"></div>', filestr)
-    filestr = re.sub(r'label\{(.+?)\}', '<div id="\g<1>"></div>', filestr)
+    # remove all index entries (could also place them
+    # in special comments to keep the information)
 
-    # Also treat special cell delimiter comments that might appear from
-    # doconce ipynb2doconce conversions
-    filestr = re.sub(r'^# ---------- (markdown|code) cell$', '',
-                     filestr, flags=re.MULTILINE)
+    filestr = re.sub(r'idx\{.+?\}' + '\n?', '', filestr)
+
+    # Use HTML anchors for labels and [link text](#label) for references
+    # outside mathematics.
+    #filestr = re.sub(r'label\{(.+?)\}', '<a name="\g<1>"></a>', filestr)
+    # Note: HTML5 should have <sometag id="..."></sometag> instead
+    filestr = re.sub(r'label\{(.+?)\}', '<div id="\g<1>"></div>', filestr)
 
     return filestr
 

--- a/lib/doconce/misc.py
+++ b/lib/doconce/misc.py
@@ -479,6 +479,7 @@ statements will come after the entire session).
 """),
     ('--ipynb_cite=', """Typesetting of bibliography.
 plain: simple native typesetting (same as pandoc) (default)
+latex-plain: Similar to latex-style plain
 latex: ipynb support for latex-style bibliographies (not mature)."""),
     ('--ipynb_admon=',
      """\


### PR DESCRIPTION
The current `latex` option does not work very well. This pull request adds an additional option to `--ipynb_cite=latex-plain` that emulates the latex plain citation style. This solves the citation part of issue #101.

New Latex-plain style:

    This is a citation [1].

    References

    1. A. (Andrea) Saltelli. Global Sensitivity Analysis : the Primer, John Wiley, 2008.

Plain style:

    This is a citation [saltelli_global_2008].

    References

    1. A. (Andrea) Saltelli. Global Sensitivity Analysis : the Primer, John Wiley, 2008.