### PR TITLE
Regex fix to replace correctly quotes that contain apostrophes

### DIFF
--- a/lib/doconce/doconce.py
+++ b/lib/doconce/doconce.py
@@ -4103,7 +4103,7 @@ def inline_tag_subst(filestr, format):
     # Do tags that require almost format-independent treatment such
     # that everything is conveniently defined here
     # 1. Quotes around normal text in LaTeX style:
-    pattern = "``([^']+?)''"  # here we had [A-Za-z][lots of chars]*?, but ^' is much smarter and mathces locale chars too
+    pattern = "``(.+?)''"
     if format in ('html',):
         filestr = re.sub(pattern, '&quot;\g<1>&quot;', filestr)
     elif format not in ('pdflatex', 'latex'):


### PR DESCRIPTION
I am not a regex pro. It seems to me that ``` ``(.+?)''``` is better than ``` ``([^']+?)'' ``` because it allows for apostrophes within the quotes. I hope I'm not missing anything obvious. 