### PR TITLE
Responsive figure width option (shrink to fit) for html version

### DIFF
--- a/lib/doconce/doconce_config_default.py
+++ b/lib/doconce/doconce_config_default.py
@@ -73,6 +73,7 @@ html_links_in_new_window = False
 #html_figure_caption =
 #html_figure_hrule =
 #html_copyright =
+html_responsive_figure_width = False
 cite_doconce = False
 #device =
 number_all_equations = False

--- a/lib/doconce/html.py
+++ b/lib/doconce/html.py
@@ -1750,6 +1750,15 @@ def html_figure(m):
     sidecaption = 0
     if opts:
         info = [s.split('=') for s in opts.split()]
+        
+        if option('html_responsive_figure_width'):
+            styleset = []
+            styleset.append("width: 100%")
+            for opt, value in info: 
+                if opt == "width": 
+                    styleset.append("max-width: %s" % value)
+            info.append(["style", "'" + "; ".join(styleset) + "'"])
+
         opts = ' '.join(['%s=%s' % (opt, value)
                          for opt, value in info
                          if opt not in ['frac', 'sidecap']])

--- a/lib/doconce/misc.py
+++ b/lib/doconce/misc.py
@@ -618,6 +618,7 @@ the document into multiple parts."""),
     ('--sphinx_figure_captions=', 'Font style in figure captions: emphasize (default) or normal. If you use boldface or emphasize in the caption, the font style will be normal for that caption.'),
     ('--oneline_paragraphs',
      'Combine paragraphs to one line (does not work well).'),
+    ('--html_responsive_figure_width', 'Use figure width as max-width, and set width to 100 percent so that figures can shrink to device width.')
     ]
 
 _legal_command_line_options = \


### PR DESCRIPTION
Adds css to all figures so as to use the width provided in the doconce document as the maximum width of the figure, and then shrink the figure to fit if the device width is smaller than that. 