### PR TITLE
Fix #187 (typo in hyperlink)

### DIFF
--- a/doc/web/index.html
+++ b/doc/web/index.html
@@ -78,7 +78,7 @@ phones.
 <br>
           <h2>Highlights</h2>
 <ul>
-  <p><li> DocOnce is a modestly tagged markup language (see <a href="http://hplgit.github.io/teamods/writing_reports/_static/report/do.txt.html" target="_self">syntax example</a>), quite like Markdown, but with many more features, aimed at documents with
+  <p><li> DocOnce is a modestly tagged markup language (see <a href="http://hplgit.github.io/teamods/writing_reports/_static/report.do.txt.html" target="_self">syntax example</a>), quite like Markdown, but with many more features, aimed at documents with
    <em>much math and code in the text</em> (see <a href="http://hplgit.github.io/teamods/writing_reports/index.html" target="_self">demo</a>).</li>
  <p><li> There is extensive support for book projects. In addition to classical LaTeX-based paper books one gets for free fully responsive, modern-looking, HTML-based ebooks for tablets and phones. Parts of books can, e.g., appear in blog posts for discussion and as IPython notebooks for experimentation and annotation.</li>
  <p><li> For documents with math and code, you can generate <em>clean</em> plain LaTeX (PDF), HTML (with MathJax and Pygments - embedded in your own templates), Sphinx for attractive web design, Markdown, IPython notebooks, HTML for Google or Wordpress blog posts, and MediaWiki. The LaTeX output has many fancy layouts for typesetting of computer code.</li>


### PR DESCRIPTION
There was a `/` instead of a `.` in the url.